### PR TITLE
 AEHS-351: Membership Entity revisionable

### DIFF
--- a/membership_entity.inc
+++ b/membership_entity.inc
@@ -102,11 +102,38 @@ class MembershipEntity extends Entity {
    * Overrides Entity::save().
    */
   public function save() {
-    if (empty($this->created)) {
-      $this->created = REQUEST_TIME;
-    }
     $this->changed = REQUEST_TIME;
-    $this->is_new_revision = TRUE;
+
+    // If this is a new entity.
+    if (!isset($this->mid)) {
+      $this->is_new_revision = TRUE;
+      $this->changed = REQUEST_TIME;
+      $this->created = REQUEST_TIME;
+      return parent::save();
+    }
+
+    // Load unchanged entity data.
+    if (!isset($this->original)) {
+      $original = entity_load_unchanged('membership_entity', $this->mid);
+    } else {
+      $original = $this->original;
+      unset($this->original);
+    }
+
+    // The entity_type property cannot be changed in the UI, so we ignore 
+    // it when comparing current and unchanged states.
+    if (isset($this->entity_type)) {
+      $original->entity_type = $this->entity_type;
+    }
+
+    // Compare new and old objects to check if any change was made.
+    if (md5(json_encode($this)) !== md5(json_encode($original))) {
+      // Flag to add a new revision.
+      $this->is_new_revision = TRUE;
+    }
+
+    // EntityAPIController will load original again if left unset.
+    $this->original = $original;
     return parent::save();
   }
 }

--- a/membership_entity.inc
+++ b/membership_entity.inc
@@ -107,7 +107,6 @@ class MembershipEntity extends Entity {
     // If this is a new entity.
     if (!isset($this->mid)) {
       $this->is_new_revision = TRUE;
-      $this->changed = REQUEST_TIME;
       $this->created = REQUEST_TIME;
       return parent::save();
     }

--- a/membership_entity.inc
+++ b/membership_entity.inc
@@ -130,12 +130,13 @@ class MembershipEntity extends Entity {
     // Load unchanged entity data.
     if (!isset($this->original)) {
       $original = entity_load_unchanged('membership_entity', $this->mid);
-    } else {
+    }
+    else {
       $original = $this->original;
       unset($this->original);
     }
 
-    // The entity_type property cannot be changed in the UI, so we ignore 
+    // The entity_type property cannot be changed in the UI, so we ignore
     // it when comparing current and unchanged states.
     if (isset($this->entity_type)) {
       $original->entity_type = $this->entity_type;

--- a/membership_entity.inc
+++ b/membership_entity.inc
@@ -106,6 +106,7 @@ class MembershipEntity extends Entity {
       $this->created = REQUEST_TIME;
     }
     $this->changed = REQUEST_TIME;
+    $this->is_new_revision = TRUE;
     return parent::save();
   }
 }

--- a/membership_entity.install
+++ b/membership_entity.install
@@ -221,7 +221,10 @@ function membership_entity_uninstall() {
 }
 
 /**
- * Add revision_id to membership_entity table and create membership_entity_revision table.
+ * Add revisions capability.
+ *
+ * Add revision_id to membership_entity table and create
+ * membership_entity_revision table.
  */
 function membership_entity_update_7001() {
   // Copied from membership_entity_schema() because the schema should not

--- a/membership_entity.install
+++ b/membership_entity.install
@@ -179,23 +179,31 @@ function membership_entity_uninstall() {
 }
 
 /**
- * Update table and create revisions for all membership entities.
+ * Add revision_id to membership_entity table and create membership_entity_revision table.
  */
 function membership_entity_update_7001() {
   $schema = membership_entity_schema();
 
-  // Create the a field for default revision.
-  db_add_field(
-    'membership_entity',
-    'revision_id',
-    $schema['membership_entity']['fields']['revision_id']
-  );
+  // Create the a field for the default revision.
+  if (!db_field_exists('membership_entity', 'revision_id')) {
+    db_add_field(
+      'membership_entity',
+      'revision_id',
+      $schema['membership_entity']['fields']['revision_id']
+    );
+  }
 
   // Create the revisions table.
-  db_create_table('membership_entity_revision', $schema['membership_entity_revision']);
+  if (!db_table_exists('membership_entity_revision')) {
+    db_create_table('membership_entity_revision', $schema['membership_entity_revision']);
+  }
+}
 
-  // Create one revision for each existing membership.
-  $memberships = membership_entity_load_multiple();
+/**
+ * Create revisions for all existing membership entities.
+ */
+function membership_entity_update_7002() {
+  $memberships = db_query('SELECT * FROM membership_entity')->fetchAll();
   foreach ($memberships as $membership) {
     $revision_id = db_insert('membership_entity_revision')
       ->fields(array(

--- a/membership_entity.install
+++ b/membership_entity.install
@@ -146,24 +146,66 @@ function membership_entity_schema() {
   );
 
   // Membership revision table.
-  $schema['membership_entity_revision'] = $schema['membership_entity'];
-  $schema['membership_entity_revision']['fields']['revision_id'] = array(
-    'type' => 'serial',
-    'not null' => TRUE,
-    'description' => 'Primary Key: Unique membership entity revision ID.',
+  $schema['membership_entity_revision'] = array(
+    'description' => 'The base table for membership revisions.',
+    'fields' => array(
+      'revision_id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique membership entity revision ID.',
+      ),
+      'mid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => 'The ID of the attached membership entity.',
+      ),
+      'member_id' => array(
+        'description' => 'A user enterable unique member id.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'type' => array(
+        'description' => 'The type (bundle) of this membership.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'description' => 'The user id of the primary member.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'status' => array(
+        'description' => 'Integer code indicating the membership status.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 1,
+      ),
+      'created' => array(
+        'description' => 'The Unix timestamp when the membership was created.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'changed' => array(
+        'description' => 'The Unix timestamp when the membership was most recently saved.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'unique keys' => array(
+      'revision_id' => array('revision_id'),
+    ),
+    'primary key' => array('revision_id'),
   );
-  $schema['membership_entity_revision']['fields']['mid'] = array(
-    'type' => 'int',
-    'unsigned' => TRUE,
-    'not null' => FALSE,
-    'default' => NULL,
-    'description' => 'The ID of the attached membership entity.',
-  );
-  $schema['membership_entity_revision']['primary key'] = array('revision_id');
-  $schema['membership_entity_revision']['unique keys'] = array(
-    'revision_id' => array('revision_id'),
-  );
-  unset($schema['membership_entity_revision']['indexes']);
 
   return $schema;
 }
@@ -182,21 +224,91 @@ function membership_entity_uninstall() {
  * Add revision_id to membership_entity table and create membership_entity_revision table.
  */
 function membership_entity_update_7001() {
-  $schema = membership_entity_schema();
+  // Copied from membership_entity_schema() because the schema should not
+  // be directly used during hook_update_N.
+  $schema['membership_entity_revision'] = array(
+    'description' => 'The base table for memberships.',
+    'fields' => array(
+      'revision_id' => array(
+        'type' => 'serial',
+        'not null' => TRUE,
+        'description' => 'Primary Key: Unique membership entity revision ID.',
+      ),
+      'mid' => array(
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+        'description' => 'The ID of the attached membership entity.',
+      ),
+      'member_id' => array(
+        'description' => 'A user enterable unique member id.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'type' => array(
+        'description' => 'The type (bundle) of this membership.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => TRUE,
+        'default' => '',
+      ),
+      'uid' => array(
+        'description' => 'The user id of the primary member.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'status' => array(
+        'description' => 'Integer code indicating the membership status.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 1,
+      ),
+      'created' => array(
+        'description' => 'The Unix timestamp when the membership was created.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'changed' => array(
+        'description' => 'The Unix timestamp when the membership was most recently saved.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+    ),
+    'unique keys' => array(
+      'revision_id' => array('revision_id'),
+    ),
+    'primary key' => array('revision_id'),
+  );
+
+  // Create the revisions table.
+  if (!db_table_exists('membership_entity_revision')) {
+    db_create_table('membership_entity_revision', $schema['membership_entity_revision']);
+  }
 
   // Create the a field for the default revision.
   if (!db_field_exists('membership_entity', 'revision_id')) {
     db_add_field(
       'membership_entity',
       'revision_id',
-      $schema['membership_entity']['fields']['revision_id']
+      array(
+        'description' => 'The default membership entity revision id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+      )
     );
   }
 
-  // Create the revisions table.
-  if (!db_table_exists('membership_entity_revision')) {
-    db_create_table('membership_entity_revision', $schema['membership_entity_revision']);
-  }
+  // Refresh schema caches.
+  $schema = drupal_get_schema(NULL, TRUE);
 }
 
 /**

--- a/membership_entity.install
+++ b/membership_entity.install
@@ -49,6 +49,13 @@ function membership_entity_schema() {
         'not null' => TRUE,
         'default' => '',
       ),
+      'revision_id' => array(
+        'description' => 'The default membership entity revision id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+      ),
       'type' => array(
         'description' => 'The type (bundle) of this membership.',
         'type' => 'varchar',
@@ -138,6 +145,26 @@ function membership_entity_schema() {
     ),
   );
 
+  // Membership revision table.
+  $schema['membership_entity_revision'] = $schema['membership_entity'];
+  $schema['membership_entity_revision']['fields']['revision_id'] = array(
+    'type' => 'serial',
+    'not null' => TRUE,
+    'description' => 'Primary Key: Unique membership entity revision ID.',
+  );
+  $schema['membership_entity_revision']['fields']['mid'] = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'default' => NULL,
+    'description' => 'The ID of the attached membership entity.',
+  );
+  $schema['membership_entity_revision']['primary key'] = array('revision_id');
+  $schema['membership_entity_revision']['unique keys'] = array(
+    'revision_id' => array('revision_id'),
+  );
+  unset($schema['membership_entity_revision']['indexes']);
+
   return $schema;
 }
 
@@ -149,4 +176,44 @@ function membership_entity_uninstall() {
   variable_del('membership_entity_settings');
   variable_del('membership_entity_next_member_id');
   variable_del('membership_entity_user_register_required');
+}
+
+/**
+ * Update table and create revisions for all membership entities.
+ */
+function membership_entity_update_7001() {
+  $schema = membership_entity_schema();
+
+  // Create the a field for default revision.
+  db_add_field(
+    'membership_entity',
+    'revision_id',
+    $schema['membership_entity']['fields']['revision_id']
+  );
+
+  // Create the revisions table.
+  db_create_table('membership_entity_revision', $schema['membership_entity_revision']);
+
+  // Create one revision for each existing membership.
+  $memberships = membership_entity_load_multiple();
+  foreach ($memberships as $membership) {
+    $revision_id = db_insert('membership_entity_revision')
+      ->fields(array(
+        'mid' => $membership->mid,
+        'member_id' => $membership->member_id,
+        'type' => $membership->type,
+        'uid' => $membership->uid,
+        'status' => $membership->status,
+        'created' => $membership->created,
+        'changed' => $membership->changed,
+      ))
+      ->execute();
+
+    db_update('membership_entity')
+      ->condition('mid', $membership->mid)
+      ->fields(array(
+        'revision_id' => $revision_id,
+      ))
+      ->execute();
+  }
 }

--- a/membership_entity.module
+++ b/membership_entity.module
@@ -43,6 +43,7 @@ function membership_entity_entity_info() {
     'entity class' => 'MembershipEntity',
     'controller class' => 'MembershipEntityController',
     'base table' => 'membership_entity',
+    'revision table' => 'membership_entity_revision',
     'label callback' => 'entity_class_label',
     'uri callback' => 'entity_class_uri',
     'access callback' => 'membership_entity_access',
@@ -51,6 +52,7 @@ function membership_entity_entity_info() {
       'id' => 'mid' ,
       'bundle' => 'type',
       'label' => 'member_id',
+      'revision' => 'revision_id',
     ),
     'bundle keys' => array(
       'bundle' => 'type',
@@ -1335,6 +1337,34 @@ function membership_entity_delete($mid) {
  */
 function membership_entity_delete_multiple($mids) {
   entity_delete_multiple('membership_entity', $mids);
+}
+
+/**
+ * Loads an entity revision.
+ */
+function membership_entity_revision_load($revision_id) {
+  return entity_revision_load('membership_entity', $revision_id);
+}
+
+/**
+ * Deletes an entity revision.
+ */
+function membership_entity_revision_delete($revision_id) {
+  return entity_revision_delete('membership_entity', $revision_id);
+}
+
+/**
+ * Checks whether the given entity is the default revision.
+ */
+function membership_entity_revision_is_default($entity) {
+  return entity_revision_is_default('membership_entity', $entity);
+}
+
+/**
+ * Sets a given entity revision as default revision.
+ */
+function membership_entity_revision_set_default($entity) {
+  entity_revision_set_default('membership_entity', $entity);
 }
 
 /**

--- a/membership_entity.module
+++ b/membership_entity.module
@@ -43,6 +43,7 @@ function membership_entity_entity_info() {
     'entity class' => 'MembershipEntity',
     'controller class' => 'MembershipEntityController',
     'base table' => 'membership_entity',
+    'revision table' => 'membership_entity_revision',
     'label callback' => 'entity_class_label',
     'uri callback' => 'entity_class_uri',
     'access callback' => 'membership_entity_access',
@@ -51,6 +52,7 @@ function membership_entity_entity_info() {
       'id' => 'mid' ,
       'bundle' => 'type',
       'label' => 'member_id',
+      'revision' => 'revision_id',
     ),
     'bundle keys' => array(
       'bundle' => 'type',
@@ -87,8 +89,10 @@ function membership_entity_entity_info() {
  * Implements hook_entity_info_alter().
  */
 function membership_entity_entity_info_alter(&$entity_info) {
-  $info['membership_entity']['revision table'] = 'membership_entity_revision';
-  $info['membership_entity']['entity keys']['revision'] = 'revision_id';
+  if (!is_array($entity_info['membership_entity']['schema_fields_sql']['revision table'])) {
+    $entity_info['membership_entity']['schema_fields_sql']['revision table'] =
+      drupal_schema_fields_sql('membership_entity_revision');
+  }
 }
 
 /**

--- a/membership_entity.module
+++ b/membership_entity.module
@@ -1353,7 +1353,6 @@ function membership_entity_delete_multiple(array $mids) {
 }
 
 /**
-<<<<<<< HEAD
  * Loads an entity revision.
  */
 function membership_entity_revision_load($revision_id) {

--- a/membership_entity.module
+++ b/membership_entity.module
@@ -43,7 +43,6 @@ function membership_entity_entity_info() {
     'entity class' => 'MembershipEntity',
     'controller class' => 'MembershipEntityController',
     'base table' => 'membership_entity',
-    'revision table' => 'membership_entity_revision',
     'label callback' => 'entity_class_label',
     'uri callback' => 'entity_class_uri',
     'access callback' => 'membership_entity_access',
@@ -52,7 +51,6 @@ function membership_entity_entity_info() {
       'id' => 'mid' ,
       'bundle' => 'type',
       'label' => 'member_id',
-      'revision' => 'revision_id',
     ),
     'bundle keys' => array(
       'bundle' => 'type',
@@ -83,6 +81,14 @@ function membership_entity_entity_info() {
   );
 
   return $info;
+}
+
+/**
+ * Implements hook_entity_info_alter().
+ */
+function membership_entity_entity_info_alter(&$entity_info) {
+  $info['membership_entity']['revision table'] = 'membership_entity_revision';
+  $info['membership_entity']['entity keys']['revision'] = 'revision_id';
 }
 
 /**

--- a/membership_entity.module
+++ b/membership_entity.module
@@ -86,16 +86,6 @@ function membership_entity_entity_info() {
 }
 
 /**
- * Implements hook_entity_info_alter().
- */
-function membership_entity_entity_info_alter(&$entity_info) {
-  if (!is_array($entity_info['membership_entity']['schema_fields_sql']['revision table'])) {
-    $entity_info['membership_entity']['schema_fields_sql']['revision table'] =
-      drupal_schema_fields_sql('membership_entity_revision');
-  }
-}
-
-/**
  * Implements hook_permission().
  */
 function membership_entity_permission() {

--- a/modules/membership_entity_type/membership_entity_type.inc
+++ b/modules/membership_entity_type/membership_entity_type.inc
@@ -83,4 +83,13 @@ class MembershipEntityType extends Entity {
   public function defaultUri() {
     return array('path' => 'admin/memberships/types/manage/' . $this->type);
   }
+
+  
+  /**
+   * Overrides Entity::save().
+   */
+  public function save() {
+    $this->is_new_revision = TRUE;
+    return parent::save();
+  }
 }

--- a/modules/membership_entity_type/membership_entity_type.inc
+++ b/modules/membership_entity_type/membership_entity_type.inc
@@ -89,7 +89,26 @@ class MembershipEntityType extends Entity {
    * Overrides Entity::save().
    */
   public function save() {
-    $this->is_new_revision = TRUE;
+    // If this is a new entity.
+    if (!isset($this->id)) {
+      $this->is_new_revision = TRUE;
+      return parent::save();
+    }
+
+    // Load unchanged entity data.
+    if (!isset($this->original)) {
+      $original = entity_load_unchanged('membership_entity_type', $this->id);
+    } else {
+      $original = $this->original;
+      unset($this->original);
+    }
+    // Compare new and old objects to check if any change was made.
+    if (md5(json_encode($this)) !== md5(json_encode($original))) {
+      // Flag to add a new revision.
+      $this->is_new_revision = TRUE;
+    }
+    // EntityAPIController will load original again if left unset.
+    $this->original = $original;
     return parent::save();
   }
 }

--- a/modules/membership_entity_type/membership_entity_type.inc
+++ b/modules/membership_entity_type/membership_entity_type.inc
@@ -102,7 +102,7 @@ class MembershipEntityType extends Entity {
   public function defaultUri() {
     return array('path' => 'admin/memberships/types/manage/' . $this->type);
   }
-  
+
   /**
    * Overrides Entity::save().
    */
@@ -116,7 +116,8 @@ class MembershipEntityType extends Entity {
     // Load unchanged entity data.
     if (!isset($this->original)) {
       $original = entity_load_unchanged('membership_entity_type', $this->id);
-    } else {
+    }
+    else {
       $original = $this->original;
       unset($this->original);
     }

--- a/modules/membership_entity_type/membership_entity_type.install
+++ b/modules/membership_entity_type/membership_entity_type.install
@@ -127,7 +127,6 @@ function membership_entity_type_schema() {
   $schema['membership_entity_type_revision']['unique keys'] = array(
     'revision_id' => array('revision_id'),
   );
-  
 
   return $schema;
 }
@@ -150,7 +149,10 @@ function membership_entity_type_install() {
 }
 
 /**
- * Add revision_id to membership_entity table and create membership_entity_revision table.
+ * Add revision_id to membership_entity table.
+ *
+ * Add revision_id to membership_entity table and create
+ * membership_entity_revision table.
  */
 function membership_entity_type_update_7001() {
   $schema = membership_entity_type_schema();

--- a/modules/membership_entity_type/membership_entity_type.install
+++ b/modules/membership_entity_type/membership_entity_type.install
@@ -103,6 +103,25 @@ function membership_entity_type_schema() {
     'primary key' => array('id'),
   );
 
+  $schema['membership_entity_type_revision'] = $schema['membership_entity_type'];
+  $schema['membership_entity_type_revision']['fields']['revision_id'] = array(
+    'type' => 'serial',
+    'not null' => TRUE,
+    'description' => 'Primary Key: Unique membership entity type revision ID.',
+  );
+  $schema['membership_entity_type_revision']['fields']['id'] = array(
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => FALSE,
+    'default' => NULL,
+    'description' => 'The ID of the attached membership entity type.',
+  );
+  $schema['membership_entity_type_revision']['primary key'] = array('revision_id');
+  $schema['membership_entity_type_revision']['unique keys'] = array(
+    'revision_id' => array('revision_id'),
+  );
+  
+
   return $schema;
 }
 
@@ -121,4 +140,56 @@ function membership_entity_type_install() {
     'data' => variable_get('membership_entity_settings', array()),
   ));
   $type->save();
+}
+
+/**
+ * Add revision_id to membership_entity table and create membership_entity_revision table.
+ */
+function membership_entity_type_update_7001() {
+  $schema = membership_entity_schema();
+
+  // Create the a field for the default revision.
+  if (!db_field_exists('membership_entity_type', 'revision_id')) {
+    db_add_field(
+      'membership_entity_type',
+      'revision_id',
+      $schema['membership_entity_type']['fields']['revision_id']
+    );
+  }
+
+  // Create the revisions table.
+  if (!db_table_exists('membership_entity_type_revision')) {
+    db_create_table(
+      'membership_entity_type_revision',
+      $schema['membership_entity_type_revision']
+    );
+  }
+}
+
+/**
+ * Create revisions for all existing membership entity types.
+ */
+function membership_entity_type_update_7002() {
+  $memberships_types = db_query('SELECT * FROM membership_entity_type')->fetchAll();
+  foreach ($memberships_types as $type) {
+    $revision_id = db_insert('membership_entity_type_revision')
+      ->fields(array(
+        'id' => $type->id,
+        'type' => $type->type,
+        'label' => $type->label,
+        'weight' => $type->weight,
+        'description' => $type->description,
+        'data' => $type->data,
+        'status' => $type->status,
+        'module' => $type->module,
+      ))
+      ->execute();
+
+    db_update('membership_entity_type')
+      ->condition('mid', $type->mid)
+      ->fields(array(
+        'revision_id' => $revision_id,
+      ))
+      ->execute();
+  }
 }

--- a/modules/membership_entity_type/membership_entity_type.install
+++ b/modules/membership_entity_type/membership_entity_type.install
@@ -46,6 +46,13 @@ function membership_entity_type_schema() {
         'type' => 'serial',
         'not null' => TRUE,
       ),
+      'revision_id' => array(
+        'description' => 'The default membership entity type revision id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'default' => NULL,
+      ),
       'type' => array(
         'description' => 'The machine-readable name of this membership entity type.',
         'type' => 'varchar',
@@ -146,7 +153,7 @@ function membership_entity_type_install() {
  * Add revision_id to membership_entity table and create membership_entity_revision table.
  */
 function membership_entity_type_update_7001() {
-  $schema = membership_entity_schema();
+  $schema = membership_entity_type_schema();
 
   // Create the a field for the default revision.
   if (!db_field_exists('membership_entity_type', 'revision_id')) {

--- a/modules/membership_entity_type/membership_entity_type.install
+++ b/modules/membership_entity_type/membership_entity_type.install
@@ -193,7 +193,7 @@ function membership_entity_type_update_7002() {
       ->execute();
 
     db_update('membership_entity_type')
-      ->condition('mid', $type->mid)
+      ->condition('id', $type->id)
       ->fields(array(
         'revision_id' => $revision_id,
       ))

--- a/modules/membership_entity_type/membership_entity_type.module
+++ b/modules/membership_entity_type/membership_entity_type.module
@@ -80,6 +80,10 @@ function membership_entity_type_entity_info_alter(&$entity_info) {
       ),
     );
   }
+
+  // Add revision capabilities to this entity.
+  $info['membership_entity_type']['revision table'] = 'membership_entity_type_revision';
+  $info['membership_entity_type']['entity keys']['revision'] = 'revision_id';
 }
 
 /**
@@ -391,6 +395,35 @@ function membership_entity_type_delete($id) {
 function membership_entity_type_delete_multiple($ids) {
   entity_delete_multiple('membership_entity_type', $ids);
 }
+
+/**
+ * Loads an entity revision.
+ */
+function membership_entity_type_revision_load($revision_id) {
+  return entity_revision_load('membership_entity_type', $revision_id);
+}
+
+/**
+ * Deletes an entity revision.
+ */
+function membership_entity_type_revision_delete($revision_id) {
+  return entity_revision_delete('membership_entity_type', $revision_id);
+}
+
+/**
+ * Checks whether the given entity is the default revision.
+ */
+function membership_entity_type_revision_is_default($entity) {
+  return entity_revision_is_default('membership_entity_type', $entity);
+}
+
+/**
+ * Sets a given entity revision as default revision.
+ */
+function membership_entity_type_revision_set_default($entity) {
+  entity_revision_set_default('membership_entity_type', $entity);
+}
+
 
 /**
  * Returns a list of membership type names.

--- a/modules/membership_entity_type/membership_entity_type.module
+++ b/modules/membership_entity_type/membership_entity_type.module
@@ -460,7 +460,6 @@ function membership_entity_type_revision_set_default($entity) {
   entity_revision_set_default('membership_entity_type', $entity);
 }
 
-
 /**
  * Returns a list of membership type names.
  *

--- a/modules/membership_entity_type/membership_entity_type.module
+++ b/modules/membership_entity_type/membership_entity_type.module
@@ -23,6 +23,7 @@ function membership_entity_type_entity_info() {
     'entity class' => 'MembershipEntityType',
     'controller class' => 'MembershipEntityTypeController',
     'base table' => 'membership_entity_type',
+    'revision table' => 'membership_entity_type_revision',
     'uri callback' => 'entity_class_uri',
     // Design decision: Membership types are fieldable to allow other modules
     // to programatically add fields at the membership type level but no field
@@ -34,6 +35,7 @@ function membership_entity_type_entity_info() {
       'id' => 'id',
       'name' => 'type',
       'label' => 'label',
+      'revision' => 'revision_id',
     ),
     'bundles' => array(
       'membership_entity_type' => array(
@@ -81,9 +83,9 @@ function membership_entity_type_entity_info_alter(&$entity_info) {
     );
   }
 
-  // Add revision capabilities to this entity.
-  $info['membership_entity_type']['revision table'] = 'membership_entity_type_revision';
-  $info['membership_entity_type']['entity keys']['revision'] = 'revision_id';
+  // Add revision capabilities to membership_entity_type entity.
+  $entity_info['membership_entity_type']['revision table'] = 'membership_entity_type_revision';
+  $entity_info['membership_entity_type']['entity keys']['revision'] = 'revision_id';
 }
 
 /**


### PR DESCRIPTION
Added:
- Revision table.
- Revision capabilities to membership_entity using EntityAPI.
- Wrappers for membership entity revision load, delete, is_default and set_default.
- Update functions for when the module is already installed, changing database structure and adding a default revision for each membership.
- A revision creation filter on MembershipEntity->save(), only allowing new revisions when the entity has changed.