### PR TITLE
AEHS-359: Coding Standards

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,8 @@ Adds automated tests.
 Issue #2400557: Syntax error on activating modules
 Join form improvements
 Issue #2375483: Add views relationship handler for secondary members
-Issue #2375479: Add subquery offset option for representative term views relationship handler
+Issue #2375479: Add subquery offset option for representative term views
+                relationship handler.
 Issue #2396395: Misspellings in code causing errors
 Issue #2394935: Missing dependency on membership_entity_term
 Issue #2351663: Anonymous join process split by verification email
@@ -16,7 +17,8 @@ Issue #2350299: Fixed PHP warnings on admin/memberships due to missing end date.
 Issue #2252779: Added Generic Renewal Page.
 No longer depend on pathauto.
 Issue #2318227: Fixed Link to edit Membership term does not respect permissions.
-Issue #2318225: Fixed Users able to view other users' Membership even when permissions forbid it.
-Issue #2315803: Fixed Views relationship Membership: Representative membership term does not respect changes to
-                representative term status.
+Issue #2318225: Fixed Users able to view other users' Membership even when
+                permissions forbid it.
+Issue #2315803: Fixed Views relationship Membership: Representative membership
+                term does not respect changes to representative term status.
 Issue #2313963: Fixed Membership term dates incorrectly handle timezones.

--- a/membership_entity.api.php
+++ b/membership_entity.api.php
@@ -2,6 +2,8 @@
 
 /**
  * @file
+ * Membership Entity API Documentation.
+ *
  * This file contains no working PHP code; it exists to provide additional
  * documentation for doxygen as well as to document hooks in the standard
  * Drupal manner.
@@ -12,7 +14,7 @@
  *
  * @param string $op
  *   The membership operation.
- * @param MembershipEntity $membership
+ * @param optional|MembershipEntity $membership
  *   The membership object. NULL if $op is 'join'.
  * @param object $account
  *   The loaded user account object. Defaults to logged in user.

--- a/membership_entity.controller.inc
+++ b/membership_entity.controller.inc
@@ -9,6 +9,7 @@
  * Entity controller class for membership entities.
  */
 class MembershipEntityController extends EntityAPIController {
+
   /**
    * Overrides EntityAPIController::create().
    */
@@ -63,7 +64,7 @@ class MembershipEntityController extends EntityAPIController {
    * @return MembershipEntity
    *   The membership object identified by member id.
    */
-  public function loadByMemberID($member_id) {
+  public function loadByMemberID($member_id) { // @codingStandardsIgnoreLine
     return reset($this->load(FALSE, array('member_id' => $member_id)));
   }
 
@@ -221,7 +222,8 @@ class MembershipEntityController extends EntityAPIController {
       throw $e;
     }
 
-    // Finish deleting the memberships;
+    // Finish deleting the memberships.
     parent::delete($mids, $transaction);
   }
+
 }

--- a/membership_entity.devel.inc
+++ b/membership_entity.devel.inc
@@ -57,7 +57,18 @@ function membership_entity_devel_generate_memberships_form($form, &$form_state) 
   }
 
   $options = array(1 => t('Now'));
-  foreach (array(86400, 604800, 2592000, 31536000, 63072000, 94608000, 126144000, 157680000, 315360000, 473040000) as $interval) {
+  foreach (array(
+    86400,
+    604800,
+    2592000,
+    31536000,
+    63072000,
+    94608000,
+    126144000,
+    157680000,
+    315360000,
+    473040000,
+  ) as $interval) {
     $options[$interval] = format_interval($interval, 1) . ' ' . t('ago');
   }
 
@@ -98,7 +109,7 @@ function membership_entity_devel_generate_memberships_form_submit($form, &$form_
  *   - multiple_type: Whether or not to allow a user to belong to multiple
  *     membership types.
  */
-function membership_entity_devel_create_memberships($values) {
+function membership_entity_devel_create_memberships(array $values) {
   // Load some devel generate helpers.
   module_load_include('inc', 'devel_generate');
   module_load_include('inc', 'devel_generate', 'devel_generate.fields');
@@ -152,7 +163,7 @@ function membership_entity_devel_create_memberships($values) {
     ));
     $membership->member_id = membership_entity_next_member_id($membership);
 
-    // Populate all core fields on behalf of field.module
+    // Populate all core fields on behalf of field.module.
     devel_generate_fields($membership, 'membership_entity', $membership->type);
     $membership->save();
 

--- a/membership_entity.inc
+++ b/membership_entity.inc
@@ -11,31 +11,43 @@
 class MembershipEntity extends Entity {
   /**
    * The primary identifier for a membership.
+   *
+   * @var int
    */
   public $mid;
 
   /**
    * A user enterable unique member id.
+   *
+   * @var int
    */
-  public $member_id;
+  public $member_id; // @codingStandardsIgnoreLine
 
   /**
    * The type (bundle) of membership.
+   *
+   * @var string
    */
   public $type;
 
   /**
    * The primary member.
+   *
+   * @var int
    */
   public $uid;
 
   /**
    * An array of secondary members.
+   *
+   * @var array
    */
-  public $secondary_members;
+  public $secondary_members; // @codingStandardsIgnoreLine
 
   /**
    * Integer code indicating the membership status.
+   *
+   * @var int
    *
    * @see membership_entity_get_status_list().
    */
@@ -43,11 +55,15 @@ class MembershipEntity extends Entity {
 
   /**
    * The Unix timestamp when the membership was created.
+   *
+   * @var int
    */
   public $created;
 
   /**
    * The Unix timestamp when the membership was most recently saved.
+   *
+   * @var int
    */
   public $changed;
 
@@ -108,4 +124,5 @@ class MembershipEntity extends Entity {
     $this->changed = REQUEST_TIME;
     return parent::save();
   }
+
 }

--- a/membership_entity.info
+++ b/membership_entity.info
@@ -10,7 +10,6 @@ dependencies[] = entity
 dependencies[] = rules
 dependencies[] = views
 
-files[] = membership_entity.module
 files[] = membership_entity.inc
 files[] = membership_entity.controller.inc
 

--- a/membership_entity.info.inc
+++ b/membership_entity.info.inc
@@ -9,6 +9,7 @@
  * Provides metadata for memberships.
  */
 class MembershipEntityMetadataController extends EntityDefaultMetadataController {
+
   /**
    * Overrides EntityDefaultMetadataController::entityPropertyInfo().
    */
@@ -69,4 +70,5 @@ class MembershipEntityMetadataController extends EntityDefaultMetadataController
     unset($properties['url']);
     return $info;
   }
+
 }

--- a/membership_entity.migrate.inc
+++ b/membership_entity.migrate.inc
@@ -9,7 +9,11 @@
  * Destination class implementing migration into memberships.
  */
 class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
-  static public function getKeySchema() {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getKeySchema() {
     return array(
       'mid' => array(
         'type' => 'int',
@@ -25,7 +29,7 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
    * @param string $language
    *   Default language for memberships created via this destination class.
    */
-  static public function options($language) {
+  public static function options($language) {
     return compact('language');
   }
 
@@ -46,14 +50,15 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
    *
    * @param Migration $migration
    *   Optionally, the migration containing this destination.
+   *
    * @return array
    *   Keys: machine names of the fields (to be passed to addFieldMapping)
    *   Values: Human-friendly descriptions of the fields.
    */
-  public function fields($migration = NULL) {
+  public function fields(Migration $migration = NULL) {
     $fields = array();
 
-    // Core membership properties
+    // Core membership properties.
     $fields['mid'] = t('Membership: Internal membership ID');
     $fields['type'] = t('Membership: The type of membership');
     $fields['member_id'] = t('Membership: The unique member ID');
@@ -64,7 +69,7 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
     $fields['changed'] = t('Membership: modified timestamp');
     $fields['is_new'] = t('Option: Indicates a new membership with the specified mid should be created');
 
-    // Add in anything provided by handlers
+    // Add in anything provided by handlers.
     $fields += migrate_handler_invoke_all('Entity', 'fields', $this->entityType, $this->bundle, $migration);
     $fields += migrate_handler_invoke_all('MembershipEntity', 'fields', $this->entityType, $this->bundle, $migration);
 
@@ -74,7 +79,7 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
   /**
    * Delete a batch of memberships at once.
    *
-   * @param $mids
+   * @param array $mids
    *   Array of membership IDs to be deleted.
    */
   public function bulkRollback(array $mids) {
@@ -88,16 +93,17 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
   /**
    * Import a single membership.
    *
-   * @param $membership
+   * @param object $membership
    *   The membership entity object to build. Prefilled with any fields mapped
    *   in the Migration.
-   * @param $row
+   * @param object $row
    *   Raw source data object - passed through to prepare/complete handlers.
+   *
    * @return array
    *   Array of key fields (mid) of the membership that was saved.
    *   FALSE on failure.
    */
-  public function import(stdClass $membership, stdClass $row) {
+  public function import($membership, $row) {
     // Migrate flattens single value arrays by default. Make sure
     // secondary_members is always an array.
     if (isset($membership->secondary_members) && !is_array($membership->secondary_members)) {
@@ -110,7 +116,7 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
     // Updating previously-migrated content?
     $migration = Migration::currentMigration();
     if (isset($row->migrate_map_destid1)) {
-      // Make sure is_new is off
+      // Make sure is_new is off.
       $membership->is_new = FALSE;
       if (isset($membership->mid)) {
         if ($membership->mid != $row->migrate_map_destid1) {
@@ -163,15 +169,16 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
       }
     }
 
-    // Invoke migration prepare handlers
+    // Invoke migration prepare handlers.
     $this->prepare($membership, $row);
 
     // Trying to update an existing membership.
     if ($migration->getSystemOfRecord() == Migration::DESTINATION) {
-      // Incoming data overrides existing data, so only copy non-existent fields
+      // Incoming data overrides existing data, so only copy non-existent
+      // fields.
       foreach ($old_membership as $field => $value) {
         if (property_exists($membership, $field) && $membership->$field === NULL) {
-          // Ignore this field
+          // Ignore this field.
           continue;
         }
         elseif (!isset($membership->$field)) {
@@ -208,4 +215,5 @@ class MigrateDestinationMembershipEntity extends MigrateDestinationEntity {
     $this->complete($membership, $row);
     return $return;
   }
+
 }

--- a/membership_entity.module
+++ b/membership_entity.module
@@ -136,7 +136,7 @@ function membership_entity_permission() {
  * @return bool
  *   TRUE if the user has access for the given operation.
  */
-function membership_entity_access($op, $membership = NULL, $account = NULL) {
+function membership_entity_access($op, MembershipEntity $membership = NULL, $account = NULL) {
   if (user_access('administer memberships', $account)) {
     return TRUE;
   }
@@ -490,7 +490,7 @@ function membership_entity_view($membership, $view_mode = 'full', $langcode = NU
       'label' => array(
         '#theme_wrappers' => array('container'),
         '#attributes' => array('class' => array('membership-entity-label')),
-        '#markup' => t('Primary Member:') . '&nbsp',
+        '#markup' => t('Primary Member:!nbsp', array('!nbsp' => '&nbsp')),
       ),
       'link' => array(
         '#type' => 'link',
@@ -735,7 +735,7 @@ function _membership_entity_extra_fields_pre_render($elements) {
 /**
  * Custom Field API validate handler.
  *
- * entity_form_field_validate() assumes the entity form elements are at the
+ * The entity_form_field_validate() assumes the entity form elements are at the
  * top level of the $form_state['values'] without regard to $form['#parents'].
  * This seems stupid. We'll just have to do it ourselves.
  */
@@ -752,7 +752,7 @@ function _membership_entity_form_field_validate($entity_type, $form, &$form_stat
 /**
  * Copies values to enitty properties.
  *
- * entity_form_submit_build_entity() assumes the entity form elements are at
+ * The entity_form_submit_build_entity() assumes the entity form elements are at
  * the top level of the $form_state['values'] without regard to
  * $form['#parents']. This seems stupid. We'll just have to do it ourselves.
  */
@@ -769,7 +769,8 @@ function _membership_entity_form_submit_build_entity($entity_type, $entity, $for
       $entity->$key = $value;
     }
 
-    // Invoke all specified builders for copying form values to entity properties.
+    // Invoke all specified builders for copying form values to entity
+    // properties.
     if (isset($form['#entity_builders'])) {
       foreach ($form['#entity_builders'] as $function) {
         $function($entity_type, $entity, $form, $form_state);
@@ -816,6 +817,7 @@ function membership_entity_get_bundles($bundle = NULL) {
  *
  * @param string $bundle
  *   The membership bundle to load settings.
+ *
  * @return array
  *   An array of bundle settings or FALSE if not configured.
  */
@@ -855,10 +857,11 @@ function membership_entity_membership_entity_bundle_settings_defaults() {
  *
  * @param MembershipEntity $membership
  *   The membership object to create a new member id. Used for tokens.
+ *
  * @return string
  *   The next available member id for the membership.
  */
-function membership_entity_next_member_id($membership) {
+function membership_entity_next_member_id(MembershipEntity $membership) {
   $data = membership_entity_get_bundle_settings($membership->type);
   return _membership_entity_member_id_get_instance($data['member_id_format'], $data['member_id_settings'])
     ->next($membership);
@@ -903,6 +906,7 @@ function membership_entity_get_member_id($id = NULL) {
  * Helper to retrieve a member id plugin instance.
  *
  * @return MembershipEntityMemberIdInterface
+ *   MembershipEntityMemberIDInterface object instance.
  */
 function _membership_entity_member_id_get_instance($id, $settings = array()) {
   $instances = &drupal_static(__FUNCTION__);
@@ -1242,13 +1246,13 @@ function membership_entity_views_api() {
  * Shallow copies all properties of $object to a new
  * MembershipEntity instance.
  *
- * @param stdClass $object
- *   The object to convert.
+ * @param object $object
+ *   The stdClass object to convert.
  *
- * @return MembershipEntity A new instance of MembershipEntity with all
- *   properties copied from $object.
+ * @return MembershipEntity
+ *   A new instance of MembershipEntity with all properties copied from $object.
  */
-function membership_entity_create_from_stdclass(stdClass $object) {
+function membership_entity_create_from_stdclass($object) {
   $membership = membership_entity_create();
   foreach (get_object_vars($object) as $key => $value) {
     $membership->{$key} = $value;
@@ -1259,11 +1263,11 @@ function membership_entity_create_from_stdclass(stdClass $object) {
 /**
  * Create a new membership entity with default values.
  *
- * @param array $values
- *  An associate array of default values for the membership.
+ * @param optioonal|array $values
+ *   An associate array of default values for the membership.
  *
- * @return MembershipEntity The new (unsaved) membership object with default
- *   values.
+ * @return MembershipEntity
+ *   The new (unsaved) membership object with default values.
  */
 function membership_entity_create($values = array()) {
   return entity_create('membership_entity', $values);
@@ -1318,13 +1322,19 @@ function membership_entity_membership_entity_presave($membership) {
 
 /**
  * Save a membership entity.
+ *
+ * @param MembershipEntity $membership
+ *   MembershipEntity to save.
  */
-function membership_entity_save(&$membership) {
+function membership_entity_save(MembershipEntity &$membership) {
   return entity_save('membership_entity', $membership);
 }
 
 /**
  * Delete a membership entity.
+ *
+ * @param int $mid
+ *   MembershipEntity ID to delete.
  */
 function membership_entity_delete($mid) {
   membership_entity_delete_multiple(array($mid));
@@ -1332,15 +1342,21 @@ function membership_entity_delete($mid) {
 
 /**
  * Delete multiple membership entities.
+ *
+ * @param array $mids
+ *   Array of MembershipEntity IDs to delete.
  */
-function membership_entity_delete_multiple($mids) {
+function membership_entity_delete_multiple(array $mids) {
   entity_delete_multiple('membership_entity', $mids);
 }
 
 /**
- * Add/Remove roles managed by the membership.
+ * Private: Add/Remove roles managed by the membership.
+ *
+ * @param array $roles
+ *   Key value array of roles keyed by role ID.
  */
-function _membership_entity_update_roles($roles) {
+function _membership_entity_update_roles(array $roles) {
   $accounts = user_load_multiple(array_keys($roles));
 
   foreach ($accounts as $uid => $account) {

--- a/membership_entity.pages.inc
+++ b/membership_entity.pages.inc
@@ -355,7 +355,7 @@ function membership_entity_join_form($form, &$form_state, $bundle = 'membership'
       '#markup' => t('Click <a href="@url">here to log in</a> if you already have an account.', array(
         '@url' => url('user/login', array('query' => drupal_get_destination())),
       )),
-      '#weight' => -9999.
+      '#weight' => -9999,
     );
 
     // Start with the default user account fields.
@@ -530,7 +530,7 @@ function membership_entity_user_join_register_validate($form, &$form_state) {
 /**
  * Submit handler for the join form registration.
  *
- * @see user_register_submit().
+ * @see user_register_submit()
  */
 function membership_entity_user_join_register_submit($form, &$form_state) {
   $values = &$form_state['values']['user'];
@@ -569,10 +569,10 @@ function membership_entity_user_join_register_submit($form, &$form_state) {
   // No e-mail verification required; log in user immediately.
   if (!variable_get('user_email_verification', TRUE) && $account->status) {
     _user_mail_notify('register_no_approval_required', $account);
-    $form_state ['uid'] = $account->uid;
+    $form_state['uid'] = $account->uid;
     user_login_submit(array(), $form_state);
     drupal_set_message(t('Registration successful. You are now logged in.'));
-    $form_state ['redirect'] = '';
+    $form_state['redirect'] = '';
   }
   // No administrator approval required.
   elseif ($account->status) {
@@ -677,7 +677,7 @@ function membership_entity_multiple_delete_confirm_submit($form, &$form_state) {
  * Open the register form in a new modal window.
  *
  * @param string $js
- *   ctools javascript status (nojs or ajax)
+ *   The ctools javascript status (nojs or ajax)
  * @param string $return_id
  *   The form element HTML id to fill with the new user id.
  */

--- a/membership_entity.test
+++ b/membership_entity.test
@@ -9,8 +9,8 @@
  * Defines a base class for testing the Membership Entity module.
  */
 class MembershipEntityWebTestCase extends DrupalWebTestCase {
-  protected $member_role;
-  protected $secondary_role;
+  protected $memberRole;
+  protected $secondaryRole;
 
   /**
    * {@inheritdoc}
@@ -29,8 +29,8 @@ class MembershipEntityWebTestCase extends DrupalWebTestCase {
     parent::setUp($modules);
 
     // Create membership roles.
-    $this->member_role = $this->drupalCreateRole(array(), 'Member');
-    $this->secondary_role = $this->drupalCreateRole(array(), 'Secondary Member');
+    $this->memberRole = $this->drupalCreateRole(array(), 'Member');
+    $this->secondaryRole = $this->drupalCreateRole(array(), 'Secondary Member');
 
     // Add default membership settings.
     variable_set('membership_entity_settings', array(
@@ -39,8 +39,8 @@ class MembershipEntityWebTestCase extends DrupalWebTestCase {
         'length' => 5,
       ),
       'cardinality' => 1,
-      'primary_role' => $this->member_role,
-      'secondary_role' => $this->secondary_role,
+      'primary_role' => $this->memberRole,
+      'secondary_role' => $this->secondaryRole,
       'show_on_profile' => 1,
       'all_edit' => 0,
     ));
@@ -49,10 +49,11 @@ class MembershipEntityWebTestCase extends DrupalWebTestCase {
   /**
    * Create and save a membership for testing.
    *
-   * @param array $values
+   * @param optional|array $values
    *   An associative array of default values for the membership.
    *
-   * @return MembershipEntity The new membership object.
+   * @return MembershipEntity
+   *   The new membership object.
    */
   public function createMembership($values = array()) {
     $membership = membership_entity_create($values);
@@ -120,7 +121,7 @@ class MembershipEntityCreateTestCase extends MembershipEntityWebTestCase {
     $this->assertText('Membership 00001 has been created.', 'Simple membership created by admin.');
 
     $member = user_load($this->member->uid);
-    if (isset($member->roles[$this->member_role])) {
+    if (isset($member->roles[$this->memberRole])) {
       $this->pass('Member role granted for membership created by admin.');
     }
     else {
@@ -154,7 +155,7 @@ class MembershipEntityCreateTestCase extends MembershipEntityWebTestCase {
     $this->assertText('Membership 00001 has been created.', 'Simple membership created by admin.');
 
     $member = user_load($this->member->uid);
-    if (isset($member->roles[$this->member_role])) {
+    if (isset($member->roles[$this->memberRole])) {
       $this->pass('Member role granted for membership created by admin.');
     }
     else {
@@ -163,7 +164,7 @@ class MembershipEntityCreateTestCase extends MembershipEntityWebTestCase {
 
     foreach (array($secondary1, $secondary2) as $secondary) {
       $secondary_member = user_load($secondary->uid);
-      if (isset($secondary_member->roles[$this->secondary_role])) {
+      if (isset($secondary_member->roles[$this->secondaryRole])) {
         $this->pass('Secondary Member role granted for membership created by admin.');
       }
       else {
@@ -182,6 +183,7 @@ class MembershipEntityCreateTestCase extends MembershipEntityWebTestCase {
  * Test membership join forms.
  */
 class MembershipEntityJoinTestCase extends MembershipEntityWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -234,7 +236,7 @@ class MembershipEntityJoinTestCase extends MembershipEntityWebTestCase {
     $this->assertText('Your membership has been created.', 'Membership created for anonymous user from the join form.');
 
     $member = user_load_by_name($username);
-    $this->assertNotNull($member->roles[$this->member_role], 'Member role granted for anonymous user from the join form.');
+    $this->assertNotNull($member->roles[$this->memberRole], 'Member role granted for anonymous user from the join form.');
 
     $membership = membership_entity_load_by_member_id('00001');
     $this->assertTrue($membership, 'Membership found in database.');
@@ -251,7 +253,7 @@ class MembershipEntityJoinTestCase extends MembershipEntityWebTestCase {
     $this->assertText('Your membership has been created.', 'Membership created for authenticated user from the join form.');
 
     $member = user_load($member->uid);
-    $this->assertNotNull($member->roles[$this->member_role], 'Member role granted for authenticated user from the join form.');
+    $this->assertNotNull($member->roles[$this->memberRole], 'Member role granted for authenticated user from the join form.');
 
     $membership = membership_entity_load_by_member_id('00001');
     $this->assertTrue($membership, 'Membership found in database.');
@@ -265,7 +267,7 @@ class MembershipEntityJoinTestCase extends MembershipEntityWebTestCase {
 class MembershipEntityEditTestCase extends MembershipEntityWebTestCase {
   private $admin;
   private $member;
-  private $secondary_member;
+  private $secondaryMember;
 
   /**
    * {@inheritdoc}
@@ -287,7 +289,7 @@ class MembershipEntityEditTestCase extends MembershipEntityWebTestCase {
     // Create some users.
     $this->admin = $this->drupalCreateUser(array('administer memberships'));
     $this->member = $this->drupalCreateUser(array('membership join'));
-    $this->secondary_member = $this->drupalCreateUser(array('membership join'));
+    $this->secondaryMember = $this->drupalCreateUser(array('membership join'));
 
     // Grant view and edit permissions for member roles.
     foreach (array('Member', 'Secondary Member') as $role_name) {
@@ -353,6 +355,7 @@ class MembershipEntityEditTestCase extends MembershipEntityWebTestCase {
  * Test membership access control.
  */
 class MembershipEntityAccessTestCase extends MembershipEntityWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -388,7 +391,7 @@ class MembershipEntityAccessTestCase extends MembershipEntityWebTestCase {
   /**
    * Test membership_entity_access function.
    */
-  function testMembershipEntityAccess() {
+  public function testMembershipEntityAccess() {
     // User without 'membership join' permission cannot access the join page.
     $user1 = $this->drupalCreateUser();
     $this->assertMembershipEntityAccess(array('join' => FALSE), 'membership', $user1);
@@ -397,16 +400,33 @@ class MembershipEntityAccessTestCase extends MembershipEntityWebTestCase {
     $admin = $this->drupalCreateUser(array('administer memberships'));
     $this->assertMembershipEntityAccess(array('join' => TRUE), 'membership', $admin);
     $membership1 = $this->createMembership(array('uid' => $user1->uid));
-    $this->assertMembershipEntityAccess(array('view' => TRUE, 'edit' => TRUE, 'delete' => TRUE), $membership1, $admin);
+    $this->assertMembershipEntityAccess(array(
+      'view' => TRUE,
+      'edit' => TRUE,
+      'delete' => TRUE,
+    ), $membership1, $admin);
 
     // Member can view, edit, and delete own membership but not any membership.
-    $permissions = array('membership join', 'membership view own membership', 'membership edit own membership', 'membership delete own membership');
+    $permissions = array(
+      'membership join',
+      'membership view own membership',
+      'membership edit own membership',
+      'membership delete own membership',
+    );
     $member1 = $this->drupalCreateUser($permissions);
     $member2 = $this->drupalCreateUser($permissions);
     $membership2 = $this->createMembership(array('uid' => $member1->uid));
     $membership3 = $this->createMembership(array('uid' => $member2->uid));
-    $this->assertMembershipEntityAccess(array('view' => TRUE, 'edit' => TRUE, 'delete' => TRUE), $membership2, $member1);
-    $this->assertMembershipEntityAccess(array('view' => FALSE, 'edit' => FALSE, 'delete' => FALSE), $membership3, $member1);
+    $this->assertMembershipEntityAccess(array(
+      'view' => TRUE,
+      'edit' => TRUE,
+      'delete' => TRUE,
+    ), $membership2, $member1);
+    $this->assertMembershipEntityAccess(array(
+      'view' => FALSE,
+      'edit' => FALSE,
+      'delete' => FALSE,
+    ), $membership3, $member1);
 
     // Secondary member can view but not edit own membership by default.
     $member2 = $this->drupalCreateUser($permissions);

--- a/membership_entity.user_register.inc
+++ b/membership_entity.user_register.inc
@@ -12,7 +12,7 @@
 /**
  * Overrides user_account_form() for the join process.
  *
- * @see membership_entity_join_form().
+ * @see membership_entity_join_form()
  */
 function membership_entity_user_account_form(&$form, &$form_state) {
   // Account information.

--- a/modules/membership_entity_term/membership_entity_term.api.php
+++ b/modules/membership_entity_term/membership_entity_term.api.php
@@ -2,6 +2,8 @@
 
 /**
  * @file
+ * MembershipEntityTerm API Description.
+ *
  * This file contains no working PHP code; it exists to provide additional
  * documentation for doxygen as well as to document hooks in the standard
  * Drupal manner.
@@ -18,7 +20,7 @@
  * @param MembershipEntityTerm $term
  *   The full membership term object.
  */
-function hook_membership_entity_term_start_date_alter(&$start, $term) {
+function hook_membership_entity_term_start_date_alter(DateObject &$start, MembershipEntityTerm $term) {
   // Determine the renewal start date.
   if (!empty($term->is_renewal)) {
     $membership = membership_entity_load($term->mid);
@@ -54,7 +56,7 @@ function hook_membership_entity_term_start_date_alter(&$start, $term) {
  * @param MembershipEntityTerm $term
  *   The full membership term object.
  */
-function hook_membership_entity_term_end_date_alter(&$end, $term) {
+function hook_membership_entity_term_end_date_alter(DateObject &$end, MembershipEntityTerm $term) {
   // Add term modifiers.
   foreach ($term->modifiers as $modifier) {
     $end = _membership_entity_term_modify_date($end, $modifier);

--- a/modules/membership_entity_term/membership_entity_term.controller.inc
+++ b/modules/membership_entity_term/membership_entity_term.controller.inc
@@ -9,6 +9,7 @@
  * Entity controller class for membership term entities.
  */
 class MembershipEntityTermController extends EntityAPIController {
+
   /**
    * Overrides EntityAPIController::create().
    */
@@ -50,6 +51,9 @@ class MembershipEntityTermController extends EntityAPIController {
     return $this->load($ids);
   }
 
+  /**
+   * {@inheritdoc}
+   */
   protected function buildQuery($ids, $conditions = array(), $revision_id = FALSE) {
     $query = parent::buildQuery($ids, $conditions, $revision_id);
 
@@ -58,4 +62,5 @@ class MembershipEntityTermController extends EntityAPIController {
     $query->addField('m', 'type', 'membership_entity_type');
     return $query;
   }
+
 }

--- a/modules/membership_entity_term/membership_entity_term.inc
+++ b/modules/membership_entity_term/membership_entity_term.inc
@@ -11,41 +11,57 @@
 class MembershipEntityTerm extends Entity {
   /**
    * The primary term identifier.
+   *
+   * @var int
    */
   public $id;
 
   /**
    * The membership identifier.
+   *
+   * @var int
    */
   public $mid;
 
   /**
    * The human readable term length. eg. 1 year.
+   *
+   * @var string
    */
   public $term;
 
   /**
    * An array term length modifiers. eg. +1 month.
+   *
+   * @var array
    */
   public $modifiers;
 
   /**
    * The date when this term starts.
+   *
+   * @var string
    */
   public $start;
 
   /**
    * The date when this term ends.
+   *
+   * @var string
    */
   public $end;
 
   /**
    * The Unix timestamp when the membership term was created.
+   *
+   * @var int
    */
   public $created;
 
   /**
    * The Unix timestamp when the membership term was most recently saved.
+   *
+   * @var int
    */
   public $changed;
 
@@ -66,7 +82,7 @@ class MembershipEntityTerm extends Entity {
   /**
    * Sets the Membership Entity.
    *
-   * @param $membership
+   * @param mixed $membership
    *   The Membership Entity object or the Membership Entity id (mid).
    */
   public function setMembership($membership) {
@@ -135,4 +151,5 @@ class MembershipEntityTerm extends Entity {
 
     $this->end = date_format_date($end, 'custom', DATE_FORMAT_DATETIME);
   }
+
 }

--- a/modules/membership_entity_term/membership_entity_term.info.inc
+++ b/modules/membership_entity_term/membership_entity_term.info.inc
@@ -9,8 +9,9 @@
  * Provides metadata for membership terms.
  */
 class MembershipEntityTermMetadataController extends EntityDefaultMetadataController {
+
   /**
-   * Overrides EntityDefaultMetadataController::entityPropertyInfo().
+   * {@inheritdoc}
    */
   public function entityPropertyInfo() {
     $info = parent::entityPropertyInfo();
@@ -71,4 +72,5 @@ class MembershipEntityTermMetadataController extends EntityDefaultMetadataContro
 
     return $info;
   }
+
 }

--- a/modules/membership_entity_term/membership_entity_term.install
+++ b/modules/membership_entity_term/membership_entity_term.install
@@ -220,10 +220,12 @@ function membership_entity_term_update_7004(&$sandbox) {
     }
 
     db_update('membership_entity_term')
-      ->fields(array(
-        'created' => $term->created,
-        'changed' => $term->changed,
-        ))
+      ->fields(
+        array(
+          'created' => $term->created,
+          'changed' => $term->changed,
+        )
+      )
       ->condition('id', $term->id)
       ->execute();
 

--- a/modules/membership_entity_term/membership_entity_term.migrate.inc
+++ b/modules/membership_entity_term/membership_entity_term.migrate.inc
@@ -9,7 +9,11 @@
  * Destination class implementing migration into memberships terms.
  */
 class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
-  static public function getKeySchema() {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getKeySchema() {
     return array(
       'id' => array(
         'type' => 'int',
@@ -22,6 +26,8 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
   /**
    * Basic initialization.
    *
+   * @param optional|string $bundle
+   *   MembershipEntityTerm bundle name to initialize.
    * @param array $options
    *   Options applied to membership terms.
    */
@@ -34,14 +40,15 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
    *
    * @param Migration $migration
    *   Optionally, the migration containing this destination.
+   *
    * @return array
    *   Keys: machine names of the fields (to be passed to addFieldMapping)
    *   Values: Human-friendly descriptions of the fields.
    */
-  public function fields($migration = NULL) {
+  public function fields(Migration $migration = NULL) {
     $fields = array();
 
-    // Core membership term properties
+    // Core membership term properties.
     $fields['id'] = t('Membership term: Internal term ID');
     $fields['mid'] = t('Membership term: The membership internal id');
     $fields['status'] = t('Membership term: The membership term status code');
@@ -51,7 +58,7 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
     $fields['end'] = t('Membership term: end date datetime');
     $fields['timezone'] = t('Membership term: Start and end date timezone');
 
-    // Add in anything provided by handlers
+    // Add in anything provided by handlers.
     $fields += migrate_handler_invoke_all('Entity', 'fields', $this->entityType, $this->bundle, $migration);
     $fields += migrate_handler_invoke_all('MembershipEntityTerm', 'fields', $this->entityType, $this->bundle, $migration);
 
@@ -61,7 +68,7 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
   /**
    * Delete a batch of memberships terms at once.
    *
-   * @param $mids
+   * @param array $ids
    *   Array of membership term IDs to be deleted.
    */
   public function bulkRollback(array $ids) {
@@ -75,23 +82,24 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
   /**
    * Import a single membership term.
    *
-   * @param $term
+   * @param object $term
    *   The membership term entity object to build. Prefilled with any fields
    *   mapped in the Migration.
-   * @param $row
+   * @param object $row
    *   Raw source data object - passed through to prepare/complete handlers.
+   *
    * @return array
    *   Array of key fields (mid) of the membership term that was saved.
    *   FALSE on failure.
    */
-  public function import(stdClass $term, stdClass $row) {
+  public function import($term, $row) {
     // Convert $term to an instance of MembershpEntityTerm.
     $term = membership_entity_term_create_from_stdclass($term);
 
     // Updating previously-migrated content?
     $migration = Migration::currentMigration();
     if (isset($row->migrate_map_destid1)) {
-      // Make sure is_new is off
+      // Make sure is_new is off.
       $term->is_new = FALSE;
       if (isset($term->id)) {
         if ($term->id != $row->migrate_map_destid1) {
@@ -144,15 +152,16 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
       }
     }
 
-    // Invoke migration prepare handlers
+    // Invoke migration prepare handlers.
     $this->prepare($term, $row);
 
     // Trying to update an existing membership term.
     if ($migration->getSystemOfRecord() == Migration::DESTINATION) {
-      // Incoming data overrides existing data, so only copy non-existent fields
+      // Incoming data overrides existing data, so only copy non-existent
+      // fields.
       foreach ($old_term as $field => $value) {
         if (property_exists($term, $field) && $term->{$field} === NULL) {
-          // Ignore this field
+          // Ignore this field.
           continue;
         }
         elseif (!isset($term->{$field})) {
@@ -195,10 +204,11 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
    *
    * @param mixed $value
    *   The incoming date value as a string or timestamp.
+   *
    * @return string
    *   The date in datetime format.
    */
-  static protected function datetime($value) {
+  protected static function datetime($value) {
     if (empty($value)) {
       $value = 'now';
     }
@@ -211,4 +221,5 @@ class MigrateDestinationMembershipEntityTerm extends MigrateDestinationEntity {
     $date = new DateObject($value, new DateTimezone('UTC'));
     return date_format_date($date, 'custom', DATE_FORMAT_DATETIME);
   }
+
 }

--- a/modules/membership_entity_term/membership_entity_term.module
+++ b/modules/membership_entity_term/membership_entity_term.module
@@ -204,15 +204,16 @@ function membership_entity_term_permission() {
 /**
  * Access callback for a membership term.
  *
- * @param $op
+ * @param string $op
  *   The operation being performed. (eg. edit, delete, renew)
- * @param $entity
+ * @param object $entity
  *   The entity object to check access. Depends on $op.
- *     - if $op is 'renew', $entity is the membership object
- *     - otherwise $entity is the term object
- * @param (optional) $account
- *   The user accout to check access for. Defaults to the logged in user.
- * @return boolean
+ *     - if $op is 'renew', $entity is the membership object.
+ *     - otherwise $entity is the term object.
+ * @param optional|object $account
+ *   The user account to check access for. Defaults to the logged in user.
+ *
+ * @return bool
  *   True if the user access to perform $op.
  */
 function membership_entity_term_access($op, $entity, $account = NULL) {
@@ -311,7 +312,8 @@ function membership_entity_term_menu() {
  * Implements hook_menu_alter().
  */
 function membership_entity_term_menu_alter(&$items) {
-  // Adjust the Field UI tabs on admin/memberships/types/manage/[membership-type].
+  // Adjust the Field UI tabs on
+  // admin/memberships/types/manage/[membership-type].
   if (module_exists('membership_entity_type')) {
     $items['admin/memberships/types/manage/%membership_entity_term_type/terms/fields']['title'] = 'Term fields';
     $items['admin/memberships/types/manage/%membership_entity_term_type/terms/fields']['weight'] = 3;
@@ -377,6 +379,12 @@ function membership_entity_term_membership_entity_term_start_date_alter(&$start,
 
 /**
  * Menu load callback for Field UI paths.
+ *
+ * @param string $name
+ *   MembershipEntityType name.
+ *
+ * @return string
+ *   MemershipEntityType bundle.
  */
 function membership_entity_term_type_load($name) {
   if ($type = membership_entity_get_bundles(strtr($name, array('-' => '_')))) {
@@ -430,6 +438,9 @@ function membership_entity_term_membership_entity_term_delete($term) {
 
 /**
  * Helper for membership term insert/update hooks.
+ *
+ * @param object $term
+ *   MembershipTerm object.
  */
 function _membership_entity_term_insert_update($term) {
   $membership = membership_entity_load($term->mid);
@@ -468,7 +479,8 @@ function membership_entity_term_membership_entity_load($memberships) {
  * Implements hook_field_info_alter().
  */
 function membership_entity_term_field_info_alter(&$info) {
-  // Add the 'membership_entity_term_renew_form' instance setting to all field types.
+  // Add the 'membership_entity_term_renew_form' instance setting to all field
+  // types.
   foreach ($info as $field_type => $field_type_info) {
     $info[$field_type]['instance_settings']['membership_entity_term_renew_form'] = FALSE;
   }
@@ -659,7 +671,7 @@ function membership_entity_term_views_api() {
 function membership_entity_term_preprocess_views_view(&$vars) {
   $view = $vars['view'];
   if ($view->name == 'membership_entity_terms') {
-    drupal_add_css(drupal_get_path('module', 'membership_entity_term') .'/css/membership_entity_term.css');
+    drupal_add_css(drupal_get_path('module', 'membership_entity_term') . '/css/membership_entity_term.css');
   }
 }
 
@@ -669,13 +681,14 @@ function membership_entity_term_preprocess_views_view(&$vars) {
  * Shallow copies all properties of $object to a new
  * MembershipEntityTerm instance.
  *
- * @param stdClass $object
+ * @param object $object
  *   The object to convert.
  *
- * @return MembershipEntityTerm A new instance of MembershipEntityTerm with all
- *   properties copied from $object.
+ * @return MembershipEntityTerm
+ *   A new instance of MembershipEntityTerm with all properties copied from
+ *   $object.
  */
-function membership_entity_term_create_from_stdclass(stdClass $object) {
+function membership_entity_term_create_from_stdclass($object) {
   $term = membership_entity_term_create();
   foreach (get_object_vars($object) as $key => $value) {
     $term->{$key} = $value;
@@ -686,10 +699,11 @@ function membership_entity_term_create_from_stdclass(stdClass $object) {
 /**
  * Create a new membership entity term with default values.
  *
- * @param array $values
+ * @param optional|array $values
  *   An assciative array of values to override the defaults.
  *
- * @return MembershipEntityTerm The (unsaved) membership term object.
+ * @return MembershipEntityTerm
+ *   The (unsaved) membership term object.
  */
 function membership_entity_term_create($values = array()) {
   return entity_create('membership_entity_term', $values);
@@ -769,6 +783,7 @@ function membership_entity_term_get_expiration_date(MembershipEntity $membership
  *
  * @param MembershipEntity|int $mid
  *   A membership object or mid.
+ *
  * @return MembershipEntityTerm
  *   The loaded membership term object or FALSE if there is no current term.
  */
@@ -778,7 +793,8 @@ function membership_entity_term_get_current($mid) {
     $mid = $mid->mid;
   }
 
-  if ($id = db_query('SELECT id FROM {membership_entity_term} t WHERE mid = :mid AND (start <= :now AND end >= :now) LIMIT 1', array(
+  if ($id = db_query('SELECT id FROM {membership_entity_term} t WHERE mid = :mid AND (start <= :now AND end >= :now) LIMIT 1',
+    array(
       ':mid' => $mid,
       ':now' => date_format_date(date_now('UTC'), 'custom', DATE_FORMAT_DATETIME),
     ))->fetchField()) {
@@ -827,7 +843,7 @@ function membership_entity_term_save($term) {
  * @return bool
  *   TRUE if the term is active or expired.
  */
-function _membership_entity_term_array_filter_expiration_status($term) {
+function _membership_entity_term_array_filter_expiration_status(MembershipEntityTerm $term) {
   return ($term->status == MEMBERSHIP_ENTITY_ACTIVE || $term->status == MEMBERSHIP_ENTITY_EXPIRED);
 }
 
@@ -838,14 +854,13 @@ function _membership_entity_term_array_filter_expiration_status($term) {
  *
  * @param MembershipEntityTerm $a
  *   The first membership entity term to sort against.
- *
  * @param MembershipEntityTerm $b
  *   The second membership entity term to sort against.
  *
  * @return MembershipEntityTerm[]
  *   An array of sorted terms by start date.
  */
-function _membership_entity_term_sort_by_start_date($a, $b) {
+function _membership_entity_term_sort_by_start_date(MembershipEntityTerm $a, MembershipEntityTerm $b) {
   $c = isset($a->start) ? $a->start : '';
   $d = isset($b->start) ? $b->start : '';
 
@@ -862,14 +877,13 @@ function _membership_entity_term_sort_by_start_date($a, $b) {
  *
  * @param MembershipEntityTerm $a
  *   The first term object to sort against.
- *
  * @param MembershipEntityTerm $b
  *   The second term object to sort against.
  *
  * @return MembershipEntityTerm[]
  *   An array of sorted terms by end date.
  */
-function _membership_entity_term_sort_by_end_date($a, $b) {
+function _membership_entity_term_sort_by_end_date(MembershipEntityTerm $a, MembershipEntityTerm $b) {
   // Lifetime terms trump all.
   if ($a->term == 'lifetime') {
     return 1;
@@ -891,7 +905,8 @@ function _membership_entity_term_sort_by_end_date($a, $b) {
 /**
  * Sort terms by weight value.
  *
- * Callback for usort() within theme_membership_entity_term_available_term_lengths_element().
+ * Callback for usort() within
+ * theme_membership_entity_term_available_term_lengths_element().
  */
 function _membership_entity_term_sort_items_by_weight($a, $b) {
   $a_weight = (is_array($a) && isset($a['weight']['#value']) ? $a['weight']['#value'] : 0);
@@ -907,7 +922,6 @@ function _membership_entity_term_sort_items_by_weight($a, $b) {
  *
  * @param DateTime $date
  *   The date object to modify.
- *
  * @param string $modifier
  *   The relative date modifier.
  *

--- a/modules/membership_entity_term/membership_entity_term.pages.inc
+++ b/modules/membership_entity_term/membership_entity_term.pages.inc
@@ -69,7 +69,7 @@ function _membership_entity_term_settings_form(&$form, &$form_state, $data) {
     '#type' => 'select',
     '#title' => t('Timezone handling'),
     '#description' => t('Select the timezone handling method for term dates. See <a href="@url">time zone handling</a> for details.', array(
-      '@url' => url('https://www.drupal.org/node/1455578', array('external' => TRUE))
+      '@url' => url('https://www.drupal.org/node/1455578', array('external' => TRUE)),
     )),
     '#default_value' => $data['tz_handling'],
     '#options' => date_timezone_handling_options(),
@@ -303,7 +303,8 @@ function membership_entity_term_create_form(&$form, &$form_state) {
     membership_entity_term_form($form, $form_state);
     $form['#validate'][] = 'membership_entity_term_form_validate';
 
-    // Hide fields where the 'membership_entity_join_form' setting is turned off.
+    // Hide fields where the 'membership_entity_join_form' setting is turned
+    // off.
     foreach (field_info_instances('membership_entity_term', $term->membership_entity_type) as $field_name => $instance) {
       if (empty($instance['settings']['membership_entity_join_form'])) {
         $form['membership_term'][$field_name]['#access'] = FALSE;
@@ -582,7 +583,7 @@ function membership_entity_term_form(&$form, &$form_state) {
 /**
  * Validate the membership entity term form.
  *
- * @see membership_entity_form_term().
+ * @see membership_entity_form_term()
  */
 function membership_entity_term_form_validate($form, &$form_state) {
   $values = &$form_state['values']['membership_term'];
@@ -723,7 +724,7 @@ function membership_entity_term_renew($form, &$form_state, $membership, $bundle 
   $latest_term = end($membership->terms);
   if ($latest_term->status == MEMBERSHIP_ENTITY_PENDING) {
     drupal_set_message(t('Your membership term is currently pending. You will not be able to renew until your term is activated. If you feel that you have received this message in error, please contact a site administrator.'), 'warning');
-    $form['actions']['submit']['#value'] .= t(' (disabled)');
+    $form['actions']['submit']['#value'] . = " " . t('(disabled)');
     $form['actions']['submit']['#attributes']['disabled'] = 'disabled';
     $form['actions']['submit']['#validate'] = array('membership_entity_term_form_disabled_validate');
   }
@@ -779,7 +780,7 @@ function membership_entity_term_edit_form_delete($form, &$form_state) {
 }
 
 /**
- * Dispaly a confirmation page before delteing a membership term.
+ * Display a confirmation page before delteing a membership term.
  */
 function membership_entity_term_delete_confirm($form, &$form_state, $membership, $term) {
   $form_state['membership'] = $membership;

--- a/modules/membership_entity_term/membership_entity_term.test
+++ b/modules/membership_entity_term/membership_entity_term.test
@@ -9,6 +9,7 @@
  * Defines a base class for testing the Membership Entity Term module.
  */
 class MembershipEntityTermWebTestCase extends MembershipEntityWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -44,10 +45,11 @@ class MembershipEntityTermWebTestCase extends MembershipEntityWebTestCase {
   /**
    * Create and save a membership term for testing.
    *
-   * @param array $values
+   * @param optional|array $values
    *   An associative array of default values for the membership type.
    *
-   * @return MembershipEntityType The new membership tyep object.
+   * @return MembershipEntityType
+   *   The new membership type object.
    */
   public function createMembershipTerm($values = array()) {
     $term = membership_entity_term_create($values);
@@ -61,6 +63,7 @@ class MembershipEntityTermWebTestCase extends MembershipEntityWebTestCase {
  * Test creating a membership term.
  */
 class MembershipEntityTermCreateTestCase extends MembershipEntityTermWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -123,6 +126,7 @@ class MembershipEntityTermCreateTestCase extends MembershipEntityTermWebTestCase
  * Test term length calculations.
  */
 class MembershipEntityTermLengthTestCase extends MembershipEntityTermWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -139,10 +143,26 @@ class MembershipEntityTermLengthTestCase extends MembershipEntityTermWebTestCase
    */
   public function testMembershipEntityTermLengths() {
     $tests = array(
-      'simple yearly' => array('1 year', '2015-01-01 00:00:00', '2016-01-01 00:00:00'),
-      'simple monthly' => array('1 month', '2015-01-01 00:00:00', '2015-02-01 00:00:00'),
-      'end of month' => array('1 month', '2015-01-31 00:00:00', '2015-02-28 00:00:00'),
-      'leap year' => array('1 year', '2012-02-29 00:00:00', '2013-02-28 00:00:00'),
+      'simple yearly' => array(
+        '1 year',
+        '2015-01-01 00:00:00',
+        '2016-01-01 00:00:00',
+      ),
+      'simple monthly' => array(
+        '1 month',
+        '2015-01-01 00:00:00',
+        '2015-02-01 00:00:00',
+      ),
+      'end of month' => array(
+        '1 month',
+        '2015-01-31 00:00:00',
+        '2015-02-28 00:00:00',
+      ),
+      'leap year' => array(
+        '1 year',
+        '2012-02-29 00:00:00',
+        '2013-02-28 00:00:00',
+      ),
       'lifetime' => array('lifetime', '2015-01-01 00:00:00', NULL),
     );
 
@@ -163,10 +183,34 @@ class MembershipEntityTermLengthTestCase extends MembershipEntityTermWebTestCase
    */
   public function testMembershipEntityTermModifiers() {
     $tests = array(
-      'extra year' => array('1 year', '+1 year', '2015-01-01 00:00:00', '2017-01-01 00:00:00'),
-      'extra 3 months' => array('1 year', '+3 months', '2015-01-01 00:00:00', '2016-04-01 00:00:00'),
-      'negative' => array('1 year', '-1 month', '2015-01-01 00:00:00', '2015-12-01 00:00:00'),
-      'multiple' => array('1 year', array('+1 year', '+2 months', '+1 day'), '2015-01-01 00:00:00', '2017-03-02 00:00:00'),
+      'extra year' => array(
+        '1 year',
+        '+1 year',
+        '2015-01-01 00:00:00',
+        '2017-01-01 00:00:00',
+      ),
+      'extra 3 months' => array(
+        '1 year',
+        '+3 months',
+        '2015-01-01 00:00:00',
+        '2016-04-01 00:00:00',
+      ),
+      'negative' => array(
+        '1 year',
+        '-1 month',
+        '2015-01-01 00:00:00',
+        '2015-12-01 00:00:00',
+      ),
+      'multiple' => array(
+        '1 year',
+        array(
+          '+1 year',
+          '+2 months',
+          '+1 day',
+        ),
+        '2015-01-01 00:00:00',
+        '2017-03-02 00:00:00',
+      ),
     );
 
     $member = $this->drupalCreateUser(array('membership join'));
@@ -189,6 +233,7 @@ class MembershipEntityTermLengthTestCase extends MembershipEntityTermWebTestCase
  * Test membership term edit forms.
  */
 class MembershipEntityTermEditTestCase extends MembershipEntityTermWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -246,7 +291,6 @@ class MembershipEntityTermEditTestCase extends MembershipEntityTermWebTestCase {
     );
     $this->drupalPost($edit_path, $edit, 'Save');
 
-
     $this->assertText('The membership term has been updated.', 'Membership term updated by admin from the edit form.');
     $this->assertText('2 years', 'Term length saved from edit form.');
     $this->assertText('02/15/2015 - 01:30', 'Term start date saved from edit form.');
@@ -259,6 +303,7 @@ class MembershipEntityTermEditTestCase extends MembershipEntityTermWebTestCase {
  * Test membership renewal forms.
  */
 class MembershipEntityTermRenewTestCase extends MembershipEntityTermWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -381,6 +426,7 @@ class MembershipEntityTermRenewTestCase extends MembershipEntityTermWebTestCase 
  * Test membership term access control.
  */
 class MembershipEntityTermAccessTestCase extends MembershipEntityTermWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -416,11 +462,14 @@ class MembershipEntityTermAccessTestCase extends MembershipEntityTermWebTestCase
   /**
    * Test membership_entity_tern_access() function.
    */
-  function testMembershipEntityTermAccess() {
+  public function testMembershipEntityTermAccess() {
     // User with 'administer membership terms' permission can do everything.
     $admin = $this->drupalCreateUser(array('administer membership terms'));
     $membership1 = $this->createMembership(array('uid' => $admin->uid));
-    $term1 = $this->createMembershipTerm(array('mid' => $membership1->mid, 'start' => format_date(REQUEST_TIME, 'custom', DATE_FORMAT_DATETIME)));
+    $term1 = $this->createMembershipTerm(array(
+      'mid' => $membership1->mid,
+      'start' => format_date(REQUEST_TIME, 'custom', DATE_FORMAT_DATETIME),
+    ));
     $this->assertMembershipEntityTermAccess(array('edit' => TRUE, 'delete' => TRUE), $term1, $admin);
     $this->assertMembershipEntityTermAccess(array('renew' => TRUE), $membership1, $admin);
 
@@ -429,12 +478,17 @@ class MembershipEntityTermAccessTestCase extends MembershipEntityTermWebTestCase
     $member1 = $this->drupalCreateUser($permissions);
     $member2 = $this->drupalCreateUser($permissions);
     $membership2 = $this->createMembership(array('uid' => $member1->uid));
-    $this->createMembershipTerm(array('mid' => $membership2->mid, 'start' => format_date(REQUEST_TIME, 'custom', DATE_FORMAT_DATETIME)));
+    $this->createMembershipTerm(array(
+      'mid' => $membership2->mid,
+      'start' => format_date(REQUEST_TIME, 'custom', DATE_FORMAT_DATETIME),
+    ));
     $membership3 = $this->createMembership(array('uid' => $member2->uid));
-    $this->createMembershipTerm(array('mid' => $membership3->mid, 'start' => format_date(REQUEST_TIME, 'custom', DATE_FORMAT_DATETIME)));
+    $this->createMembershipTerm(array(
+      'mid' => $membership3->mid,
+      'start' => format_date(REQUEST_TIME, 'custom', DATE_FORMAT_DATETIME),
+    ));
     $this->assertMembershipEntityTermAccess(array('renew' => TRUE), $membership2, $member1);
     $this->assertMembershipEntityTermAccess(array('remew' => FALSE), $membership3, $member1);
   }
 
 }
-

--- a/modules/membership_entity_term/membership_entity_term.ui.inc
+++ b/modules/membership_entity_term/membership_entity_term.ui.inc
@@ -9,12 +9,14 @@
  * Membership term UI controller.
  */
 class MembershipEntityTermUIController extends EntityDefaultUIController {
+
   /**
    * {@inheritdoc}
    */
-  public function hook_menu() {
+  public function hook_menu() { // @codingStandardsIgnoreLine, EntityDefaultIOController override compliant
     $items = parent::hook_menu();
     $items[$this->path]['description'] = 'Manage membership terms and fields.';
     return $items;
   }
+
 }

--- a/modules/membership_entity_term/views/membership_entity_term.views.inc
+++ b/modules/membership_entity_term/views/membership_entity_term.views.inc
@@ -9,10 +9,11 @@
  * Membership entity term views controller class.
  */
 class MembershipEntityTermViewsController extends EntityDefaultViewsController {
+
   /**
    * Overrides EntityDefaultViewsController::views_data().
    */
-  public function views_data() {
+  public function views_data() { // @codingStandardsIgnoreLine, Views override compliant
     $info = parent::views_data();
     $data = &$info['membership_entity_term'];
 
@@ -49,6 +50,7 @@ class MembershipEntityTermViewsController extends EntityDefaultViewsController {
 
     return $info;
   }
+
 }
 
 /**

--- a/modules/membership_entity_term/views/views_handler_field_membership_term_datetime.inc
+++ b/modules/membership_entity_term/views/views_handler_field_membership_term_datetime.inc
@@ -8,11 +8,12 @@
 /**
  * Field handler for membership term dates.
  */
-class views_handler_field_membership_term_datetime extends views_handler_field_date {
+class views_handler_field_membership_term_datetime extends views_handler_field_date { // @codingStandardsIgnoreLine, Views override compliant
+
   /**
    * {@inheritdoc}
    */
-  function construct() {
+  public function construct() {
     parent::construct();
     $this->additional_fields['mid'] = 'mid';
     $this->additional_fields['timezone'] = 'timezone';
@@ -21,7 +22,7 @@ class views_handler_field_membership_term_datetime extends views_handler_field_d
   /**
    * {@inheritdoc}
    */
-  function options_form(&$form, &$form_state) {
+  public function options_form(&$form, &$form_state) { // @codingStandardsIgnoreLine, Views override compliant
     parent::options_form($form, $form_state);
 
     $form['timezone'] = array(
@@ -33,7 +34,7 @@ class views_handler_field_membership_term_datetime extends views_handler_field_d
   /**
    * {@inheritdoc}
    */
-  public function get_value($values, $field = NULL) {
+  public function get_value($values, $field = NULL) { // @codingStandardsIgnoreLine, Views override compliant
     $value = parent::get_value($values, $field);
     if (empty($field) || $field == $this->real_field) {
       $date = new DateObject($value, 'UTC');
@@ -45,7 +46,7 @@ class views_handler_field_membership_term_datetime extends views_handler_field_d
   /**
    * {@inheritdoc}
    */
-  function render($values) {
+  public function render($values) {
     // Load the membership object and settings.
     if ($mid = $this->get_value($values, 'mid')) {
       $type = db_query("SELECT type FROM {membership_entity} WHERE mid = :mid", array(':mid' => $mid))->fetchColumn();
@@ -56,4 +57,5 @@ class views_handler_field_membership_term_datetime extends views_handler_field_d
       return parent::render($values);
     }
   }
+
 }

--- a/modules/membership_entity_term/views/views_handler_field_membership_term_modifier.inc
+++ b/modules/membership_entity_term/views/views_handler_field_membership_term_modifier.inc
@@ -8,11 +8,12 @@
 /**
  * Field handler to provide a list of term modifiers.
  */
-class views_handler_field_membership_term_modifier extends views_handler_field_serialized {
+class views_handler_field_membership_term_modifier extends views_handler_field_serialized { // @codingStandardsIgnoreLine, Views override compliant
+
   /**
    * {@inheritdoc}
    */
-  function option_definition() {
+  public function option_definition() { // @codingStandardsIgnoreLine, Views override compliant
     $options = parent::option_definition();
     $options['format'] = array('default' => 'list');
     $options['list_type'] = array('default' => 'separator');
@@ -23,7 +24,7 @@ class views_handler_field_membership_term_modifier extends views_handler_field_s
   /**
    * {@inheritdoc}
    */
-  function options_form(&$form, &$form_state) {
+  public function options_form(&$form, &$form_state) { // @codingStandardsIgnoreLine, Views override compliant
     parent::options_form($form, $form_state);
 
     $form['format']['#options'] = array_merge(array('list' => t('As a list')), $form['format']['#options']);
@@ -54,7 +55,7 @@ class views_handler_field_membership_term_modifier extends views_handler_field_s
   /**
    * {@inheritdoc}
    */
-  function render($values) {
+  public function render($values) {
     if ($this->options['format'] != 'list') {
       return parent::render($values);
     }
@@ -73,4 +74,5 @@ class views_handler_field_membership_term_modifier extends views_handler_field_s
       }
     }
   }
+
 }

--- a/modules/membership_entity_term/views/views_handler_filter_membership_term_datetime.inc
+++ b/modules/membership_entity_term/views/views_handler_filter_membership_term_datetime.inc
@@ -8,9 +8,14 @@
 /**
  * A handler to filter on the membership term dates.
  */
-class views_handler_filter_membership_term_datetime extends date_views_filter_handler_simple {
-  function init(&$view, &$options) {
+class views_handler_filter_membership_term_datetime extends date_views_filter_handler_simple { // @codingStandardsIgnoreLine, Views override compliant
+
+  /**
+   * {@inheritdoc}
+   */
+  public function init(&$view, &$options) {
     parent::init($view, $options);
     $this->date_handler->date_type = DATE_DATETIME;
   }
+
 }

--- a/modules/membership_entity_term/views/views_handler_relationship_term_groupwise_max.inc
+++ b/modules/membership_entity_term/views/views_handler_relationship_term_groupwise_max.inc
@@ -8,11 +8,12 @@
 /**
  * Relationship handler that allows a groupwise maximum of the linked term.
  */
-class views_handler_relationship_term_groupwise_max extends views_handler_relationship_groupwise_max {
+class views_handler_relationship_term_groupwise_max extends views_handler_relationship_groupwise_max { // @codingStandardsIgnoreLine, Views override compliant
+
   /**
    * Defines default values for options.
    */
-  function option_definition() {
+  function option_definition() { // @codingStandardsIgnoreLine, Views override compliant
     $options = parent::option_definition();
     $options['subquery_status'] = array('default' => array());
     $options['subquery_offset'] = array('default' => 0);
@@ -22,7 +23,7 @@ class views_handler_relationship_term_groupwise_max extends views_handler_relati
   /**
    * Extends the relationship's basic options.
    */
-  function options_form(&$form, &$form_state) {
+  function options_form(&$form, &$form_state) { // @codingStandardsIgnoreLine, Views override compliant
     parent::options_form($form, $form_state);
 
     // Form type checkboxes may not use 0 as an options key. We'll use -1
@@ -58,12 +59,16 @@ class views_handler_relationship_term_groupwise_max extends views_handler_relati
    *
    * This is mostly a copy of parent::left_query except adding a status
    * condition and allowing multiple representative relationships.
+   *
+   * @todo: could we use a call to parent::left_query, and modify from there?
+   * Also needs to be refactored to reduce cyclometric complexity, turn some of
+   * The conditionals into private methods on the class.
    */
-  function left_query($options) {
+  function left_query($options) { // @codingStandardsIgnoreLine, Views override compliant
     // Either load another view, or create one on the fly.
     if ($options['subquery_view']) {
       $temp_view = views_get_view($options['subquery_view']);
-      // Remove all fields from default display
+      // Remove all fields from default display.
       unset($temp_view->display['default']->display_options['fields']);
     }
     else {
@@ -84,8 +89,8 @@ class views_handler_relationship_term_groupwise_max extends views_handler_relati
     }
 
     // Get the namespace string.
-    $temp_view->namespace = (!empty($options['subquery_namespace'])) ? '_'. $options['subquery_namespace'] : '_INNER';
-    $this->subquery_namespace = (!empty($options['subquery_namespace'])) ? '_'. $options['subquery_namespace'] : 'INNER';
+    $temp_view->namespace = (!empty($options['subquery_namespace'])) ? '_' . $options['subquery_namespace'] : '_INNER';
+    $this->subquery_namespace = (!empty($options['subquery_namespace'])) ? '_' . $options['subquery_namespace'] : 'INNER';
 
     // The value we add here does nothing, but doing this adds the right tables
     // and puts in a WHERE clause with a placeholder we can grab later.
@@ -173,7 +178,7 @@ class views_handler_relationship_term_groupwise_max extends views_handler_relati
     // into a SelectQuery that it does not recognize (because it's outer) just
     // makes it treat it as a string. We use a pattern to match multiple
     // relationships.
-    $outer_pattern  = '/:' . str_replace('.', '_', $this->definition['outer field']) . '\d*/i';
+    $outer_pattern = '/:' . str_replace('.', '_', $this->definition['outer field']) . '\d*/i';
 
     // Handle outer field from a relationship.
     list($outer_table, $outer_field) = explode('.', $this->definition['outer field']);
@@ -185,4 +190,5 @@ class views_handler_relationship_term_groupwise_max extends views_handler_relati
     $subquery_sql = str_replace(array_keys($args), $args, $subquery_sql);
     return $subquery_sql;
   }
+
 }

--- a/modules/membership_entity_type/membership_entity_type.controller.inc
+++ b/modules/membership_entity_type/membership_entity_type.controller.inc
@@ -9,8 +9,9 @@
  * Entity controller class for membership types.
  */
 class MembershipEntityTypeController extends EntityAPIControllerExportable {
+
   /**
-   * Overrides EntityAPIControllerExportable::create().
+   * {@inheritdoc}
    */
   public function create(array $values = array()) {
     $values += array(
@@ -31,7 +32,7 @@ class MembershipEntityTypeController extends EntityAPIControllerExportable {
   }
 
   /**
-   * Overrides EntityAPIControllerExportable::save().
+   * {@inheritdoc}
    */
   public function save($type, DatabaseTransaction $transaction = NULL) {
     $status = parent::save($type, $transaction);
@@ -42,4 +43,5 @@ class MembershipEntityTypeController extends EntityAPIControllerExportable {
 
     return $status;
   }
+
 }

--- a/modules/membership_entity_type/membership_entity_type.inc
+++ b/modules/membership_entity_type/membership_entity_type.inc
@@ -9,6 +9,7 @@
  * Defines a membership type.
  */
 class MembershipEntityType extends Entity {
+
   public $id;
   public $label;
   public $type;
@@ -19,7 +20,7 @@ class MembershipEntityType extends Entity {
   /**
    * Default constructor for membership types.
    *
-   * @param array $values
+   * @param optional|array $values
    *   An array of default values.
    */
   public function __construct($values = array()) {
@@ -28,6 +29,12 @@ class MembershipEntityType extends Entity {
 
   /**
    * Returns the full url to the membership type.
+   *
+   * @param optional|string $context
+   *   String containing context action.
+   *
+   * @return string
+   *   URL to action from context, or default URL.
    */
   public function url($context = NULL) {
     $uri = $this->uri($context);
@@ -36,6 +43,12 @@ class MembershipEntityType extends Entity {
 
   /**
    * Returns the Drupal path to the membership type.
+   *
+   * @param optional|string $context
+   *   String containing context action.
+   *
+   * @return string
+   *   URI to action from context, or default URI.
    */
   public function path($context = NULL) {
     $uri = $this->uri($context);
@@ -43,7 +56,7 @@ class MembershipEntityType extends Entity {
   }
 
   /**
-   * Returns a type uri.
+   * {@inheritdoc}
    */
   public function uri($context = NULL) {
     if (isset($this->entityInfo['uri callback']) && $this->entityInfo['uri callback'] == 'entity_class_uri') {
@@ -63,6 +76,9 @@ class MembershipEntityType extends Entity {
 
   /**
    * Return a path the membership type join form.
+   *
+   * @return array
+   *   Array containing the path string, keyed by "path".
    */
   public function joinUri() {
     $type_url_str = str_replace('_', '-', $this->type);
@@ -71,6 +87,9 @@ class MembershipEntityType extends Entity {
 
   /**
    * Return a path the membership type admin create form.
+   *
+   * @return array
+   *   Array containing the path string, keyed by "path".
    */
   public function adminUri() {
     $type_url_str = str_replace('_', '-', $this->type);
@@ -83,4 +102,5 @@ class MembershipEntityType extends Entity {
   public function defaultUri() {
     return array('path' => 'admin/memberships/types/manage/' . $this->type);
   }
+
 }

--- a/modules/membership_entity_type/membership_entity_type.info.inc
+++ b/modules/membership_entity_type/membership_entity_type.info.inc
@@ -9,8 +9,9 @@
  * Provides metadata for membership types.
  */
 class MembershipEntityTypeMetadataController extends EntityDefaultMetadataController {
+
   /**
-   * Overrides EntityDefaultMetadataController::entityPropertyInfo().
+   * {@inheritdoc}
    */
   public function entityPropertyInfo() {
     $info = parent::entityPropertyInfo();
@@ -22,4 +23,5 @@ class MembershipEntityTypeMetadataController extends EntityDefaultMetadataContro
 
     return $info;
   }
+
 }

--- a/modules/membership_entity_type/membership_entity_type.module
+++ b/modules/membership_entity_type/membership_entity_type.module
@@ -147,7 +147,11 @@ function membership_entity_type_menu() {
       'title' => $type->label,
       'title callback' => 'check_plain',
       'page callback' => 'drupal_get_form',
-      'page arguments' => array('membership_entity_edit_form', NULL, $type->type),
+      'page arguments' => array(
+        'membership_entity_edit_form',
+        NULL,
+        $type->type,
+      ),
       'access arguments' => array('administer memberships'),
       'description' => $type->description,
       'file' => 'membership_entity.pages.inc',
@@ -287,6 +291,9 @@ function membership_entity_type_theme($existing, $type, $theme, $path) {
  *
  * @param string $machine_name
  *   Get information about a specific type. NULL to return all types.
+ *
+ * @return array
+ *   Array of MembershipEntityTypes, keyed by machine name.
  */
 function membership_entity_type_get_types($machine_name = NULL) {
   $types = &drupal_static(__FUNCTION__, array());
@@ -339,11 +346,12 @@ function membership_entity_type_field_extra_fields() {
 
 /**
  * Create a new membership entity type with default values.
-
- * @param array $values
+ *
+ * @param optional|array $values
  *   An associative array of settings to override the defaults.
  *
- * @return MembershipEntityType The new (unsaved) membership type object.
+ * @return MembershipEntityType
+ *   The new (unsaved) membership type object.
  */
 function membership_entity_type_create($values = array()) {
   return entity_create('membership_entity_type', $values);
@@ -354,10 +362,11 @@ function membership_entity_type_create($values = array()) {
  *
  * @param int|string $id
  *   The type id or machine name.
- * @param boolean $reset
+ * @param bool $reset
  *   TRUE to rebuild cached data.
  *
- * @return MembershipEntityType The loaded membership type object.
+ * @return MembershipEntityType
+ *   The loaded membership type object.
  */
 function membership_entity_type_load($id = NULL, $reset = FALSE) {
   $types = membership_entity_type_load_multiple(array($id), array(), $reset);
@@ -366,6 +375,17 @@ function membership_entity_type_load($id = NULL, $reset = FALSE) {
 
 /**
  * Loads multiple membership type objects.
+ *
+ * @param mixed $ids
+ *   Array of MembershipEntityType ids, or FALSE.
+ * @param optional|array $conditions
+ *   Optional array of conditions used to filter returned entities.
+ * @param bool $reset
+ *   Whether to reset the internal cache for the requested entity type.
+ *
+ * @return array
+ *   An array of entity objects indexed by their ids, or an empty array if no
+ *   results are found.
  */
 function membership_entity_type_load_multiple($ids = FALSE, $conditions = array(), $reset = FALSE) {
   return entity_load('membership_entity_type', $ids, $conditions, $reset);
@@ -373,13 +393,24 @@ function membership_entity_type_load_multiple($ids = FALSE, $conditions = array(
 
 /**
  * Save a membership entity type.
+ *
+ * @param MembershipEntityType $type
+ *   MembershipEntityType object to save.
+ *
+ * @return int|false
+ *   For entity types provided by the CRUD API, SAVED_NEW or SAVED_UPDATED is
+ *   returned depending on the operation performed. If there is no information
+ *   how to save the entity, FALSE is returned.
  */
-function membership_entity_type_save(&$type) {
+function membership_entity_type_save(MembershipEntityType &$type) {
   return entity_save('membership_entity_type', $type);
 }
 
 /**
  * Delete a membership entity type.
+ *
+ * @param int $id
+ *   MembershipEntityType id to delete.
  */
 function membership_entity_type_delete($id) {
   membership_entity_type_delete_multiple(array($id));
@@ -387,13 +418,19 @@ function membership_entity_type_delete($id) {
 
 /**
  * Delete multiple membership entities.
+ *
+ * @param array $ids
+ *   Array of MembershipEntity ids to delete.
  */
-function membership_entity_type_delete_multiple($ids) {
+function membership_entity_type_delete_multiple(array $ids) {
   entity_delete_multiple('membership_entity_type', $ids);
 }
 
 /**
  * Returns a list of membership type names.
+ *
+ * @return array
+ *   Array containing list of membership types, keyed by machine name.
  */
 function membership_entity_type_get_names() {
   $types = membership_entity_type_get_types();
@@ -409,16 +446,26 @@ function membership_entity_type_get_names() {
  *
  * @param MembershipEntity $membership
  *   The membership object to get the type name.
+ *
+ * @return string
+ *   MembershipEntity type , or empty string.
  */
-function membership_entity_type_get_name($membership) {
+function membership_entity_type_get_name(MembershipEntity $membership) {
   $names = membership_entity_type_get_names();
   return isset($names[$membership->type]) ? $names[$membership->type] : '';
 }
 
 /**
  * Title callback for a membership type.
+ *
+ * @param MembershipEntityType $type
+ *   Membership Entity Type object.
+ *
+ * @return string
+ *   String containing the MembershipEntityType (bundle) used for the admin
+ *   Interface title.
  */
-function membership_entity_type_page_title($type) {
+function membership_entity_type_page_title(MembershipEntityType $type) {
   return $type->label;
 }
 

--- a/modules/membership_entity_type/membership_entity_type.pages.inc
+++ b/modules/membership_entity_type/membership_entity_type.pages.inc
@@ -10,6 +10,9 @@
  *
  * @param string $context
  *   The context for adding a membership. Join or admin.
+ *
+ * @return string
+ *   Themed output as an HTML string.
  */
 function membership_entity_type_membership_add_page($context = 'join') {
   // Load membership types.
@@ -35,6 +38,9 @@ function membership_entity_type_membership_add_page($context = 'join') {
 
 /**
  * Page callback: Displays renew links for available membership types.
+ *
+ * @return array
+ *   Output array ready for theming.
  */
 function membership_entity_type_renew_page() {
   // Get a list of membership types for the current user.
@@ -80,9 +86,15 @@ function membership_entity_type_renew_page() {
     $output['table']['#rows'][] = array(
       array('data' => $membership->member_id),
       array('data' => membership_entity_type_get_name($membership)),
-      array('data' => l(t('Renew'), 'user/renew/' . $type_url_string, array(
-        'attributes' => array('class' => array('button')),
-      ))),
+      array(
+        'data' => l(t('Renew'), 'user/renew/' . $type_url_string,
+          array(
+            'attributes' => array(
+              'class' => array('button'),
+            ),
+          ),
+        ),
+      ),
     );
   }
 
@@ -91,8 +103,14 @@ function membership_entity_type_renew_page() {
 
 /**
  * Returns HTML for a list of available membership types.
+ *
+ * @param array $variables
+ *   Theme layer Drupal variables array.
+ *
+ * @return string
+ *   HTML output for theme layer.
  */
-function theme_membership_entity_type_add_list($variables) {
+function theme_membership_entity_type_add_list(array $variables) {
   $types = $variables['types'];
   $context = $variables['context'];
   $membership_entity_term = module_exists('membership_entity_term');
@@ -101,17 +119,21 @@ function theme_membership_entity_type_add_list($variables) {
   if (!empty($types)) {
     $rows = array(
       'type' => array(array()),
-      'description' => array(array(
-        'data' => t('Description'),
-        'header' => TRUE,
-      )),
+      'description' => array(
+        array(
+          'data' => t('Description'),
+          'header' => TRUE,
+        ),
+      ),
     );
 
     if ($membership_entity_term) {
-      $rows['terms'] = array(array(
-        'data' => t('Term Options'),
-        'header' => TRUE,
-      ));
+      $rows['terms'] = array(
+        array(
+          'data' => t('Term Options'),
+          'header' => TRUE,
+        ),
+      );
     }
 
     $rows['join'] = array(array());
@@ -122,15 +144,23 @@ function theme_membership_entity_type_add_list($variables) {
     $rows['description'][] = array('data' => check_plain($type->description));
 
     if ($membership_entity_term) {
-      $rows['terms'][] = array('data' => theme('item_list', array(
-        'items' => array_map('check_plain', $type->data['available_term_lengths']),
-        'type' => 'ul',
-      )));
+      $rows['terms'][] = array(
+        'data' => theme('item_list',
+          array(
+            'items' => array_map('check_plain', $type->data['available_term_lengths']),
+            'type' => 'ul',
+          ),
+        ),
+      );
     }
 
-    $rows['join'][] = array('data' => l(t('Select'), $type->path($context), array(
-      'attributes' => array('class' => array('button')),
-    )));
+    $rows['join'][] = array(
+      'data' => l(t('Select'), $type->path($context), array(
+        'attributes' => array(
+          'class' => array('button'),
+        ),
+      )),
+    );
   }
 
   return theme('table', array(

--- a/modules/membership_entity_type/membership_entity_type.test
+++ b/modules/membership_entity_type/membership_entity_type.test
@@ -9,6 +9,7 @@
  * Defines a base class for testing the Membership Entity Type module.
  */
 class MembershipEntityTypeWebTestCase extends MembershipEntityWebTestCase {
+
   /**
    * {@inheritdoc}
    */
@@ -40,10 +41,11 @@ class MembershipEntityTypeWebTestCase extends MembershipEntityWebTestCase {
   /**
    * Create and save a membership type for testing.
    *
-   * @param array $values
+   * @param optional|array $values
    *   An associative array of default values for the membership type.
    *
-   * @return MembershipEntityType The new membership tyep object.
+   * @return MembershipEntityType
+   *   The new membership tyep object.
    */
   public function createMembershipType($values = array()) {
     if (!isset($values['data'])) {
@@ -72,6 +74,7 @@ class MembershipEntityTypeWebTestCase extends MembershipEntityWebTestCase {
  * Test membership type creation functions.
  */
 class MembershipEntityTypeCreateTestCase extends MembershipEntityTypeWebTestCase {
+
   /**
    * {@inheritdoc}
    */

--- a/modules/membership_entity_type/membership_entity_type.ui.inc
+++ b/modules/membership_entity_type/membership_entity_type.ui.inc
@@ -9,20 +9,34 @@
  * Membership type UI controller.
  */
 class MembershipEntityTypeUIController extends EntityDefaultUIController {
+
   /**
    * {@inheritdoc}
    */
-  public function hook_menu() {
+  public function hook_menu() { // @codingStandardsIgnoreLine, EntityDefaultUIController override compliant
     $items = parent::hook_menu();
     $items[$this->path]['description'] = 'Manage membership types and fields.';
     return $items;
   }
+
 }
 
 /**
  * Creates the membership entity type edit form.
+ *
+ * @param array $form
+ *   Form API form array.
+ * @param array $form_state
+ *   Form API form state array.
+ * @param string $type
+ *   Membership Entity bundle type.
+ * @param optional|string $op
+ *   Operation being performed in form.
+ *
+ * @return array
+ *   Modified Form API form array.
  */
-function membership_entity_type_form($form, &$form_state, $type, $op = 'edit') {
+function membership_entity_type_form(array $form, array &$form_state, $type, $op = 'edit') {
   if ($op == 'clone') {
     $type->label .= ' (cloned)';
     $type->type .= '_clone';

--- a/modules/membership_entity_type/views/membership_entity_type.views.inc
+++ b/modules/membership_entity_type/views/membership_entity_type.views.inc
@@ -9,10 +9,11 @@
  * Membership entity type views controller class.
  */
 class MembershipEntityTypeViewsController extends EntityDefaultViewsController {
+
   /**
    * Overrides EntityDefaultViewsController::views_data().
    */
-  public function views_data() {
+  public function views_data() { // @codingStandardsIgnoreLine, EntityDefaultViewsController override compliant
     $info = parent::views_data();
     $data = &$info['membership_entity_type'];
 
@@ -54,4 +55,5 @@ class MembershipEntityTypeViewsController extends EntityDefaultViewsController {
 
     return $info;
   }
+
 }

--- a/plugins/member_id/MembershipEntityNumericMemberId.class.php
+++ b/plugins/member_id/MembershipEntityNumericMemberId.class.php
@@ -5,11 +5,15 @@
  * Contains the MembershipEntityNumericMemberId class.
  */
 
+/**
+ * MembershipEntityNumbericMemberId class.
+ */
 class MembershipEntityNumericMemberId extends MembershipEntityMemberIdAbstract {
+
   /**
-   * Returns the next available member id.
+   * {@inheritdoc}
    */
-  public function next($membership) {
+  public function next(MembershipEntity $membership) {
     $settings = $this->settings;
     $length = !empty($settings['length']) ? $settings['length'] : 5;
     $member_id = variable_get('membership_entity_next_member_id', 0);
@@ -18,7 +22,7 @@ class MembershipEntityNumericMemberId extends MembershipEntityMemberIdAbstract {
   }
 
   /**
-   * Builds the settings form for the member id.
+   * {@inheritdoc}
    */
   public function settingsForm(&$form_state) {
     $settings = $this->settings;
@@ -35,7 +39,7 @@ class MembershipEntityNumericMemberId extends MembershipEntityMemberIdAbstract {
   }
 
   /**
-   * Validate the settings form.
+   * {@inheritdoc}
    */
   public function validateSettings(&$element, &$form_state) {
     $schema = drupal_get_schema('membership_entity');
@@ -45,4 +49,5 @@ class MembershipEntityNumericMemberId extends MembershipEntityMemberIdAbstract {
       )));
     }
   }
+
 }

--- a/plugins/member_id/MembershipEntityTokenMemberId.class.php
+++ b/plugins/member_id/MembershipEntityTokenMemberId.class.php
@@ -5,11 +5,20 @@
  * Contains the MembershipEntityTokenMemberId class.
  */
 
+/**
+ * MembershipEntityTokenMemberId class.
+ *
+ * @todo: move private functions into class as private methods.  This will
+ * break the API but would be more compliant with coding standards to make
+ * these private methods instead of private functions, and would assure
+ * strict compliance with the module's API.  Implement as part of version 2.0.
+ */
 class MembershipEntityTokenMemberId extends MembershipEntityMemberIdAbstract {
+
   /**
-   * Returns the next available member id.
+   * {@inheritdoc}
    */
-  public function next($membership) {
+  public function next(MembershipEntity $membership) {
     $settings = $this->settings + array(
       'pattern' => '',
       'suffix' => 1,
@@ -61,9 +70,9 @@ class MembershipEntityTokenMemberId extends MembershipEntityMemberIdAbstract {
   }
 
   /**
-   * Builds the settings form for the member id.
+   * {@inheritdoc}
    */
-  public function settingsForm(&$form_state) {
+  public function settingsForm(array &$form_state) {
     $settings = $this->settings + array(
       'pattern' => '',
       'suffix' => 1,
@@ -78,7 +87,7 @@ class MembershipEntityTokenMemberId extends MembershipEntityMemberIdAbstract {
     );
 
     $form['pattern'] = array(
-      '#type'=> 'textfield',
+      '#type' => 'textfield',
       '#title' => t('Member ID Pattern.'),
       '#description' => t('The pattern to use to create the member id. You may enter data from the "Replacement patterns" below.'),
       '#required' => TRUE,
@@ -115,10 +124,10 @@ class MembershipEntityTokenMemberId extends MembershipEntityMemberIdAbstract {
       '#size' => 5,
       '#states' => array(
         'required' => array(
-          'input[name="member_id_settings[suffix]"]' => array('checked' => TRUE)
+          'input[name="member_id_settings[suffix]"]' => array('checked' => TRUE),
         ),
         'visible' => array(
-          'input[name="member_id_settings[suffix]"]' => array('checked' => TRUE)
+          'input[name="member_id_settings[suffix]"]' => array('checked' => TRUE),
         ),
       ),
       '#default_value' => $settings['length'],
@@ -175,7 +184,7 @@ class MembershipEntityTokenMemberId extends MembershipEntityMemberIdAbstract {
   /**
    * Element validate callback to check the Member ID token pattern field.
    *
-   * @see token_element_validate().
+   * @see token_element_validate()
    */
   public function patternElementValidate(&$element, &$form_state) {
     $value = isset($element['#value']) ? $element['#value'] : $element['#default_value'];
@@ -199,31 +208,54 @@ class MembershipEntityTokenMemberId extends MembershipEntityMemberIdAbstract {
     if (isset($element['#token_types'])) {
       $invalid_tokens = token_get_invalid_tokens_by_context($tokens, $element['#token_types']);
       if ($invalid_tokens) {
-        form_error($element, t('The %element-title is using the following invalid tokens: @invalid-tokens.', array('%element-title' => $title, '@invalid-tokens' => implode(', ', $invalid_tokens))));
+        form_error($element, t('The %element-title is using the following invalid tokens: @invalid-tokens.',
+          array(
+            '%element-title' => $title,
+            '@invalid-tokens' => implode(', ', $invalid_tokens),
+          )
+        ));
       }
     }
 
     return $element;
   }
+
 }
 
 /**
- * Token callback to clean a replacement value.
+ * Private: Token callback to clean a replacement value.
+ *
+ * @param array $replacements
+ *   Array of tokens and values to clean.
+ * @param optional|array $data
+ *   Does not appear to be used anywhere in the method call.
+ * @param optional|array $options
+ *   Array of settings to apply to the token value to clean it.
  */
-function _membership_entity_token_member_id_token_callback(&$replacements, $data = array(), $options = array()) {
+function _membership_entity_token_member_id_token_callback(array &$replacements, $data = array(), $options = array()) {
   foreach ($replacements as $token => $value) {
     $replacements[$token] = _membership_entity_token_clean_string($value, $options['settings']);
   }
 }
 
 /**
- * Apply advanced options to a generated member id string.
+ * Private: Apply advanced options to a generated member id string.
+ *
+ * @param string $string
+ *   Original member id string.
+ * @param array $settings
+ *   Array of settings to apply to string.
+ *
+ * @return string
+ *   Sanitized member id string.
+ *
+ * @todo document content of $settings array.
  */
-function _membership_entity_token_clean_string($string, $settings) {
+function _membership_entity_token_clean_string($string, array $settings) {
   // Remove all HTML tags from the string.
   $return = strip_tags(decode_entities($string));
 
-  // Get rid of words that are on the ignore list
+  // Get rid of words that are on the ignore list.
   $ignore_words = $settings['ignore_words'];
   $ignore_words_regex = preg_replace(array('/^[,\s]+|[,\s]+$/', '/[,\s]+/'), array('', '\b|\b'), $ignore_words);
   if ($ignore_words_regex) {
@@ -241,7 +273,7 @@ function _membership_entity_token_clean_string($string, $settings) {
   if ($settings['case'] == 'lower') {
     $return = drupal_strtolower($return);
   }
-  else if ($settings['case'] == 'upper') {
+  elseif ($settings['case'] == 'upper') {
     $return = drupal_strtoupper($return);
   }
 
@@ -254,7 +286,15 @@ function _membership_entity_token_clean_string($string, $settings) {
 }
 
 /**
- * Replace whitespace and punctuation with a separator.
+ * Private: Replace whitespace and punctuation with a separator.
+ *
+ * @param string $string
+ *   Original string to be converted.
+ * @param string $separator
+ *   Separator to apply to string.
+ *
+ * @return string
+ *   Modified string with separator applied.
  */
 function _membership_entity_token_clean_separator($string, $separator) {
   $return = $string;
@@ -262,7 +302,14 @@ function _membership_entity_token_clean_separator($string, $separator) {
     $return = preg_replace('/\s+/', $separator, $return);
 
     // Replace punctuation.
-    $punctuation = array('"', '\'', '`', ',', '.', '-', '_', ':', ';', '|', '{', '[', '}', ']', '+', '=', '*', '&', '%', '^', '$', '#', '@', '!', '~', '(', ')', '?', '<', '>', '/', '\\');
+    $punctuation = array(
+      '"', '\'', '`', ',', '.', '-', '_',
+      ':', ';', '|', '{', '[', '}', ']',
+      '+', '=', '*', '&', '%', '^', '$',
+      '#', '@', '!', '~', '(', ')', '?',
+      '<', '>', '/', '\\',
+    );
+
     $return = str_replace($punctuation, $separator, $return);
 
     // Escape the separator.
@@ -275,4 +322,5 @@ function _membership_entity_token_clean_separator($string, $separator) {
     $return = preg_replace("/$pattern+/", $separator, $return);
   }
   return $return;
+
 }

--- a/plugins/member_id/abstract.inc
+++ b/plugins/member_id/abstract.inc
@@ -9,6 +9,7 @@
  * Additional member_id formats for a membership type.
  */
 interface MembershipEntityMemberIdInterface {
+
   /**
    * Determines the next available member id.
    *
@@ -18,17 +19,32 @@ interface MembershipEntityMemberIdInterface {
    * @return string
    *   The next available member id.
    */
-  public function next($membership);
+  public function next(MembershipEntity $membership);
 
   /**
    * Builds the settings form this handler.
+   *
+   * @param array $form_state
+   *   The Form API form_state array.
+   *
+   * @return array
+   *   The Form API form array.
+   *
+   * @todo determine if form_state parameter is actually needed, since it
+   * is not used within the method.
    */
-  public function settingsForm(&$form_state);
+  public function settingsForm(array &$form_state);
 
   /**
    * Validates the plugin settings form.
+   *
+   * @param array $element
+   *   Form API element array.
+   * @param array $form_state
+   *   Form API form_state array.
    */
-  public function validateSettings(&$element, &$form_state);
+  public function validateSettings(array &$element, array &$form_state);
+
 }
 
 /**
@@ -37,6 +53,8 @@ interface MembershipEntityMemberIdInterface {
 abstract class MembershipEntityMemberIdAbstract implements MembershipEntityMemberIdInterface {
   /**
    * The settings options.
+   *
+   * @var array
    */
   protected $settings;
 
@@ -46,34 +64,36 @@ abstract class MembershipEntityMemberIdAbstract implements MembershipEntityMembe
    * @param array $settings
    *   An array of default plugin settings.
    */
-  public function __construct($settings) {
+  public function __construct(array $settings) {
     $this->settings = $settings;
   }
 
   /**
-   * Implements MembershipEntityMemberIdInterface::next().
+   * {@inheritdoc}
    */
-  public function next($membership) {}
+  public function next(MembershipEntity $membership) {}
 
   /**
-   * Implements MembershipEntityMemberIdInterface::settingsForm().
+   * {@inheritdoc}
    */
-  public function settingsForm(&$form_state) {
+  public function settingsForm(array &$form_state) {
     return array();
   }
 
   /**
-   * Implements MembershipEntityMemberIdInterface::validateSettings().
+   * {@inheritdoc}
    */
-  public function validateSettings(&$element, &$form_state) {}
+  public function validateSettings(array &$element, array &$form_state) {}
+
 }
 
 /**
  * A broken implementation of MembershipEntityMemberId.
  */
 class MembershipEntityMemberIdBroken extends MembershipEntityMemberIdAbstract {
+
   /**
-   * {@inheritdoc}}
+   * {@inheritdoc}
    */
   public function next($membership) {}
 
@@ -86,4 +106,5 @@ class MembershipEntityMemberIdBroken extends MembershipEntityMemberIdAbstract {
     );
     return $form;
   }
+
 }

--- a/views/membership_entity.views.inc
+++ b/views/membership_entity.views.inc
@@ -9,10 +9,11 @@
  * Provides views integration for memberships.
  */
 class MembershipEntityViewsController extends EntityDefaultViewsController {
+
   /**
    * Overrides EntityDefaultViewsController::views_data().
    */
-  public function views_data() {
+  public function views_data() { // @codingStandardsIgnoreLine, EntityDefaultViewsController override compliant
     $info = parent::views_data();
     $data = &$info['membership_entity'];
 
@@ -102,4 +103,5 @@ class MembershipEntityViewsController extends EntityDefaultViewsController {
 
     return $info;
   }
+
 }

--- a/views/views_handler_field_membership_link.inc
+++ b/views/views_handler_field_membership_link.inc
@@ -8,8 +8,20 @@
 /**
  * Field handler to show a link to the membership.
  */
-class views_handler_field_membership_link extends views_handler_field_entity {
-  public $entity_info;
+class views_handler_field_membership_link extends views_handler_field_entity { // @codingStandardsIgnoreLine, Views override compliant
+
+  /**
+   * Store Entity Information array returned by entity_get_info().
+   *
+   * @var array
+   */
+  public $entityInfo;
+
+  /**
+   * Operation beig performed.
+   *
+   * @var array
+   */
   public $op;
 
   /**
@@ -17,18 +29,18 @@ class views_handler_field_membership_link extends views_handler_field_entity {
    */
   public function init(&$view, &$options) {
     parent::init($view, $options);
-    $this->entity_info = entity_get_info($this->entity_type);
+    $this->entityInfo = entity_get_info($this->entity_type);
     $this->op = $this->definition['op'];
 
     // Add the primary key field.
-    $key = $this->entity_info['entity keys']['id'];
+    $key = $this->entityInfo['entity keys']['id'];
     $this->additional_fields[$key] = $key;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function option_definition() {
+  public function option_definition() { // @codingStandardsIgnoreLine, Views override compliant
     $options = parent::option_definition();
     $options['text'] = array('default' => $this->op, 'translatable' => TRUE);
     return $options;
@@ -37,7 +49,7 @@ class views_handler_field_membership_link extends views_handler_field_entity {
   /**
    * {@inheritdoc}
    */
-  public function options_form(&$form, &$form_state) {
+  public function options_form(&$form, &$form_state) { // @codingStandardsIgnoreLine, Views override compliant
     $form['text'] = array(
       '#type' => 'textfield',
       '#title' => t('Text to display'),
@@ -61,7 +73,7 @@ class views_handler_field_membership_link extends views_handler_field_entity {
   /**
    * {@inheritdoc}
    */
-  public function render($values) {
+  public function render($values) { // @codingStandardsIgnoreLine, Views override compliant
     if ($entity = $this->get_value($values)) {
       return $this->render_link($entity, $values);
     }
@@ -78,7 +90,7 @@ class views_handler_field_membership_link extends views_handler_field_entity {
    * @return string
    *   HTML for the membership link.
    */
-  public function render_link($entity, $values) {
+  public function render_link(Entity $entity, array $values) { // @codingStandardsIgnoreLine, Views override compliant
     if (entity_access($this->op, $this->entity_type, $entity)) {
       $this->options['alter']['make_link'] = TRUE;
       $uri = entity_uri($this->entity_type, $entity);
@@ -91,4 +103,5 @@ class views_handler_field_membership_link extends views_handler_field_entity {
       return $text;
     }
   }
+
 }

--- a/views/views_handler_field_membership_primary_member.inc
+++ b/views/views_handler_field_membership_primary_member.inc
@@ -8,11 +8,12 @@
 /**
  * Field handler to show the primary member from the membership.
  */
-class views_handler_field_membership_primary_member extends entity_views_handler_field_entity {
+class views_handler_field_membership_primary_member extends entity_views_handler_field_entity { // @codingStandardsIgnoreLine, Views override compliant
+
   /**
    * {@inheritdoc}
    */
-  public function options_form(&$form, &$form_state) {
+  public function options_form(&$form, &$form_state) { // @codingStandardsIgnoreLine, Views override compliant
     parent::options_form($form, $form_state);
 
     $form['display']['#options'] = array(
@@ -26,4 +27,5 @@ class views_handler_field_membership_primary_member extends entity_views_handler
 
     $form['bypass_access']['#description'] = t('If enabled, access permissions for rendering the user are not checked.');
   }
+
 }

--- a/views/views_handler_field_membership_secondary_member.inc
+++ b/views/views_handler_field_membership_secondary_member.inc
@@ -8,7 +8,8 @@
 /**
  * Field handler to provide a list of secondary members.
  */
-class views_handler_field_membership_secondary_member extends views_handler_field_prerender_list {
+class views_handler_field_membership_secondary_member extends views_handler_field_prerender_list { // @codingStandardsIgnoreLine, Views override compliant
+
   /**
    * {@inheritdoc}
    */
@@ -20,7 +21,7 @@ class views_handler_field_membership_secondary_member extends views_handler_fiel
   /**
    * {@inheritdoc}
    */
-  public function option_definition() {
+  public function option_definition() { // @codingStandardsIgnoreLine, Views override compliant
     $options = parent::option_definition();
     $options['display'] = array('default' => 'label');
     $options['link_to_user'] = array('default' => TRUE, 'bool' => TRUE);
@@ -30,7 +31,7 @@ class views_handler_field_membership_secondary_member extends views_handler_fiel
   /**
    * {@inheritdoc}
    */
-  public function options_form(&$form, &$form_state) {
+  public function options_form(&$form, &$form_state) { // @codingStandardsIgnoreLine, Views override compliant
     parent::options_form($form, $form_state);
 
     $form['type']['#options'] += array(
@@ -68,7 +69,7 @@ class views_handler_field_membership_secondary_member extends views_handler_fiel
   /**
    * {@inheritdoc}
    */
-  public function pre_render(&$values) {
+  public function pre_render(&$values) { // @codingStandardsIgnoreLine, Views override compliant
     if (empty($values)) {
       return;
     }
@@ -91,14 +92,14 @@ class views_handler_field_membership_secondary_member extends views_handler_fiel
   /**
    * {@inheritdoc}
    */
-  public function render_item($count, $item) {
+  public function render_item($count, $item) { // @codingStandardsIgnoreLine, Views override compliant
     return $item['uid'];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function render_items($values) {
+  public function render_items($values) { // @codingStandardsIgnoreLine, Views override compliant
     if (empty($values)) {
       return;
     }
@@ -134,7 +135,7 @@ class views_handler_field_membership_secondary_member extends views_handler_fiel
   /**
    * {@inheritdoc}
    */
-  public function render_link($value) {
+  public function render_link($value) { // @codingStandardsIgnoreLine, Views override compliant
     $account = user_load($value);
     if ($this->options['display'] == 'label') {
       $value = format_username($account);
@@ -146,4 +147,5 @@ class views_handler_field_membership_secondary_member extends views_handler_fiel
     }
     return $render;
   }
+
 }


### PR DESCRIPTION
This commit fixes coding standards in the following files:

*	modified:   CHANGELOG.txt
*	modified:   membership_entity.api.php
*	modified:   membership_entity.controller.inc
*	modified:   membership_entity.devel.inc
*	modified:   membership_entity.inc
*	modified:   membership_entity.info
*	modified:   membership_entity.info.inc
*	modified:   membership_entity.migrate.inc
*	modified:   membership_entity.module
*	modified:   membership_entity.pages.inc
*	modified:   membership_entity.test
*	modified:   membership_entity.user_register.inc
*	modified:   modules/membership_entity_term/membership_entity_term.api.php
*	modified:   modules/membership_entity_term/membership_entity_term.controller.inc
*	modified:   modules/membership_entity_term/membership_entity_term.inc
*	modified:   modules/membership_entity_term/membership_entity_term.info.inc
*	modified:   modules/membership_entity_term/membership_entity_term.install
*	modified:   modules/membership_entity_term/membership_entity_term.migrate.inc
*	modified:   modules/membership_entity_term/membership_entity_term.module
*	modified:   modules/membership_entity_term/membership_entity_term.pages.inc
*	modified:   modules/membership_entity_term/membership_entity_term.test
*	modified:   modules/membership_entity_term/membership_entity_term.ui.inc
*	modified:   modules/membership_entity_term/views/membership_entity_term.views.inc
*	modified:   modules/membership_entity_term/views/views_handler_field_membership_term_datetime.inc
*	modified:   modules/membership_entity_term/views/views_handler_field_membership_term_modifier.inc
*	modified:   modules/membership_entity_term/views/views_handler_filter_membership_term_datetime.inc
*	modified:   modules/membership_entity_term/views/views_handler_relationship_term_groupwise_max.inc
*	modified:   modules/membership_entity_type/membership_entity_type.controller.inc
*	modified:   modules/membership_entity_type/membership_entity_type.inc
*	modified:   modules/membership_entity_type/membership_entity_type.info.inc
*	modified:   modules/membership_entity_type/membership_entity_type.module
*	modified:   modules/membership_entity_type/membership_entity_type.pages.inc
*	modified:   modules/membership_entity_type/membership_entity_type.test
*	modified:   modules/membership_entity_type/membership_entity_type.ui.inc
*	modified:   modules/membership_entity_type/views/membership_entity_type.views.inc
*	modified:   plugins/member_id/MembershipEntityNumericMemberId.class.php
*	modified:   plugins/member_id/MembershipEntityTokenMemberId.class.php
*	modified:   plugins/member_id/abstract.inc
*	modified:   views/membership_entity.views.inc
*	modified:   views/views_handler_field_membership_link.inc
*	modified:   views/views_handler_field_membership_primary_member.inc
*	modified:   views/views_handler_field_membership_secondary_member.inc

Several tags were added to skip coding standards checks by CodeSniffer
because, while not compliant, they are standards established by the Views
or the Entity modules, and the naming conventions comply with what is
dictated by those modules for successful class extension and method over-
rides.

Docblocks, parameter and return value documentation, type hints and
inline documentation also added.

On branch feature-AEHS-359-coding-standards