### PR TITLE
AEHS-365 Prevent PHP warning while renewing membership with no terms

### DIFF
--- a/modules/membership_entity_term/membership_entity_term.module
+++ b/modules/membership_entity_term/membership_entity_term.module
@@ -452,7 +452,7 @@ function _membership_entity_term_insert_update($term) {
   }
   else {
     $latest = end($membership->terms);
-    $membership->status = $latest->status;
+    $membership->status = $latest ? $latest->status : MEMBERSHIP_ENTITY_PENDING;
     $membership->save();
   }
 }

--- a/modules/membership_entity_term/membership_entity_term.pages.inc
+++ b/modules/membership_entity_term/membership_entity_term.pages.inc
@@ -722,7 +722,8 @@ function membership_entity_term_renew($form, &$form_state, $membership, $bundle 
 
   // Check for a pending renewal.
   $latest_term = end($membership->terms);
-  if ($latest_term->status == MEMBERSHIP_ENTITY_PENDING) {
+
+  if ($latest_term && $latest_term->status == MEMBERSHIP_ENTITY_PENDING) {
     drupal_set_message(t('Your membership term is currently pending. You will not be able to renew until your term is activated. If you feel that you have received this message in error, please contact a site administrator.'), 'warning');
     $form['actions']['submit']['#value'] . = " " . t('(disabled)');
     $form['actions']['submit']['#attributes']['disabled'] = 'disabled';


### PR DESCRIPTION
**Steps to reproduce:**

On a clean site, enable membership_entity, membership_entity_type and membership_entity_term.
Set permissions:

Join as a Membership member OK OK OK
Renew own Membership membership NO OK OK
View own Membership membership NO OK OK
Edit own Membership membership NO OK OK
Setup (add possible term lengths) default membership type (/admin/memberships/types/manage/membership).
Create a test user and login.
Click Join and choose any term length.
Login as admin, go to user page (/user/<user_id>) and edit and delete term length.
Login as test user again and click Renew.

**Fix:**
To prevent this warning, first check if membership latest term variable isn't FALSE. When the membership terms array is empty, this variable will be FALSE. The warning trigger when this boolean is treated like an object, trying to get the status property.

The case of membership_entity_term.module:455 puts the membership on pending status if it has no term, also avoiding warning when term array is empty.