### PR TITLE
AEHS-364: Lifetime views get_value method warning fix

### DIFF
--- a/modules/membership_entity_term/views/views_handler_field_membership_term_datetime.inc
+++ b/modules/membership_entity_term/views/views_handler_field_membership_term_datetime.inc
@@ -36,7 +36,7 @@ class views_handler_field_membership_term_datetime extends views_handler_field_d
    */
   public function get_value($values, $field = NULL) { // @codingStandardsIgnoreLine, Views override compliant
     $value = parent::get_value($values, $field);
-    if (empty($field) || $field == $this->real_field) {
+    if ((empty($field) || $field == $this->real_field) && !empty($value)) {
       $date = new DateObject($value, 'UTC');
       return $date->format('U');
     }


### PR DESCRIPTION
Steps to reproduce:
1. On a clean Drupal installation, enable membership_entity and membership_entity_term modules.
2. Configure membership (/admin/memberships/types/manage/membership) with lifetime term.
3. On a test user, join with lifetime term.
4. On /user you will see the warnings.

Fix:
A view handler for datetime on method get_value was not accounting for NULL dates, that is the case of the end date for lifetime term.