### PR TITLE
AEHS-363: Calculate term start date using the latest active term

### DIFF
--- a/modules/membership_entity_term/membership_entity_term.module
+++ b/modules/membership_entity_term/membership_entity_term.module
@@ -358,7 +358,7 @@ function membership_entity_term_membership_entity_term_start_date_alter(&$start,
   if (!empty($term->is_renewal)) {
     $membership = membership_entity_load($term->mid);
     $bundle_settings = membership_entity_get_bundle_settings($membership->type);
-    $latest_term = end($membership->terms);
+    $latest_term = membership_entity_term_get_latest($membership);
 
     if (!empty($latest_term)) {
       $grace = new DateObject($latest_term->end, 'UTC');
@@ -375,6 +375,37 @@ function membership_entity_term_membership_entity_term_start_date_alter(&$start,
       }
     }
   }
+}
+
+/**
+ * Get the latest active term of a membership.
+ *
+ * @param int or MembershipEntity
+ *   MembershipEntity object or membership id.
+ *
+ * @return MembershipEntityTerm
+ *   Latest term of a membership.
+ */
+function membership_entity_term_get_latest($membership) {
+  if (is_numeric($membership)) {
+    $membership = membership_entity_load($membership);
+  }
+  $latest_term = NULL;
+  if (isset($membership->terms)) {
+    foreach ($membership->terms as $term) {
+      if ($term->status == MEMBERSHIP_ENTITY_ACTIVE) {
+        if ($latest_term) {
+          if (strtotime($latest_term->end) < strtotime($term->end)) {
+            $latest_term = $term;
+          }
+        }
+        else {
+          $latest_term = $term;
+        }
+      }
+    }
+  }
+  return $latest_term;
 }
 
 /**


### PR DESCRIPTION
To reproduce this I had to change the status of terms directly on the database. Admin could set up Rules to change term status or do it by code. I notice that the start date of the new term is always the end date of the last term, even if that is not an active term.
The solution I've implemented was to create a new function that retrieves the latest active term and use it to calculate the start date of new terms.